### PR TITLE
Fase C — Virtual Cockpit + 2D Panel + Sketchpad (M15 + M16 + M17)

### DIFF
--- a/MACOS_ROADMAP.md
+++ b/MACOS_ROADMAP.md
@@ -368,6 +368,7 @@ Ogni milestone comincia con:
 
 - **M15 — interactive verification**: smoke tests confermano zero-crash cross-scenario ma l'acceptance visiva del ciclo F1 → VC (mesh cockpit, look-around, MFD rendering, HUD overlay, area click response) richiede sessione desktop. Da sottoporre ad human-in-the-loop prima del tag release.
 - **M15 — Area compositing su texture compresse**: `clbkBlt` su `tgt` loaded da DDS compressa (DXT) potrebbe fallire FBO completeness check (`OGLSurface::EnsureFBO` su texture DXT). Se si manifesta in scenari reali: aggiungere path di "decompress-on-first-area-bind" che ricrea la texture come RGBA8 prima del primo blit. Non-blocking: strumentale solo se VC areas risultano nere in un vessel che usa esclusivamente DDS compresse per i mesh group con area targets.
+- **M17 — Interactive MFD acceptance**: smoke tests confermano zero-crash su 4 scenari, ma la parità visiva (Orbit trace, Map coastline, HSI needle, Docking crosshair, Surface altimetry, Atmospheric autopilot HUD) richiede sessione desktop human-in-the-loop. Aspetti particolari da verificare: (a) line widths >1 su Apple M-series GL (fallback triangle-quads attivato); (b) text baseline alignment, fixed-width vs proportional fonts, `CalcWordWrapPosition` tramite default `TextBox`; (c) LuaMFD chiamando `SetBrightness` / `SetRenderParam(PRM_GAMMA)`; (d) plugin ScnEditor che usa `DrawMeshGroup` per preview 3D mini-globes.
 
 ---
 
@@ -392,7 +393,7 @@ Ogni milestone comincia con:
 | M14 | Runway lights+annotations | B | ✅ | this branch (M14 planetarium grid + M14.b pad beacons/OGLvBase) |
 | M15 | Virtual Cockpit | C | ✅ | this branch (M15.a re-enable F1 + M15.b vismode/dual-pass + M15.c MFD texture compositing + M15.d HUD overlay/click zones) |
 | M16 | 2D Panel | C | ✅ | this branch (UsrFlag skip + MFD slot resolution via GetMFDSurface + mesh-local fallback for NULL hSurf) |
-| M17 | MFD Sketchpad 100% | C | ☐ | — |
+| M17 | MFD Sketchpad 100% | C | ✅ | this branch (M17.a FBO retarget + M17.b colour transforms + M17.c blit/state/shape/text extras + M17.d transform stack / view-proj / clipping / mesh draw) |
 | M18 | IAudioBackend + OpenAL | D | ☐ | — |
 | M19 | CString + irrKlang shim | D | ☐ | — |
 | M20 | XRSound core integration | D | ☐ | — |

--- a/MACOS_ROADMAP.md
+++ b/MACOS_ROADMAP.md
@@ -391,7 +391,7 @@ Ogni milestone comincia con:
 | M13 | Glare/corona | B | ✅ | this branch |
 | M14 | Runway lights+annotations | B | ✅ | this branch (M14 planetarium grid + M14.b pad beacons/OGLvBase) |
 | M15 | Virtual Cockpit | C | ✅ | this branch (M15.a re-enable F1 + M15.b vismode/dual-pass + M15.c MFD texture compositing + M15.d HUD overlay/click zones) |
-| M16 | 2D Panel | C | ☐ | — |
+| M16 | 2D Panel | C | ✅ | this branch (UsrFlag skip + MFD slot resolution via GetMFDSurface + mesh-local fallback for NULL hSurf) |
 | M17 | MFD Sketchpad 100% | C | ☐ | — |
 | M18 | IAudioBackend + OpenAL | D | ☐ | — |
 | M19 | CString + irrKlang shim | D | ☐ | — |

--- a/MACOS_ROADMAP.md
+++ b/MACOS_ROADMAP.md
@@ -364,6 +364,11 @@ Ogni milestone comincia con:
 - **M7.b** — ✅ **DONE**: elevation displacement via `ELEVFILEHEADER` parse (uint8/int8/uint16/int16 dtypes supported), bilinear sampling in `BuildSpherePatch`. Crack-hiding skirts + proper per-vertex normal finite-differences restano come polish pass futuro (non-blocking, visually correct as-is).
 - **M14.b** — ✅ **DONE**: OGLvBase enumera ogni base del pianeta via `oapiGetBaseCount`/`oapiGetBasePadCount`/`oapiGetBasePadEquPos`, converte a world-coords con `oapiEquToGlobal`, e emette landing pad beacons (bianchi + rossi alternati stile PAPI-like) via `OGLBeaconArray` con cutoff a 500 km. Full `.bse` mesh parser (tarmacs, hangars) resta polish futuro — il contributo visibile più forte (luci pad) è coperto.
 
+### Follow-up Fase C — polish non-bloccanti post-M15
+
+- **M15 — interactive verification**: smoke tests confermano zero-crash cross-scenario ma l'acceptance visiva del ciclo F1 → VC (mesh cockpit, look-around, MFD rendering, HUD overlay, area click response) richiede sessione desktop. Da sottoporre ad human-in-the-loop prima del tag release.
+- **M15 — Area compositing su texture compresse**: `clbkBlt` su `tgt` loaded da DDS compressa (DXT) potrebbe fallire FBO completeness check (`OGLSurface::EnsureFBO` su texture DXT). Se si manifesta in scenari reali: aggiungere path di "decompress-on-first-area-bind" che ricrea la texture come RGBA8 prima del primo blit. Non-blocking: strumentale solo se VC areas risultano nere in un vessel che usa esclusivamente DDS compresse per i mesh group con area targets.
+
 ---
 
 ## Stato avanzamento
@@ -385,7 +390,7 @@ Ogni milestone comincia con:
 | M12 | Particle systems | B | ✅ | this branch |
 | M13 | Glare/corona | B | ✅ | this branch |
 | M14 | Runway lights+annotations | B | ✅ | this branch (M14 planetarium grid + M14.b pad beacons/OGLvBase) |
-| M15 | Virtual Cockpit | C | ☐ | — |
+| M15 | Virtual Cockpit | C | ✅ | this branch (M15.a re-enable F1 + M15.b vismode/dual-pass + M15.c MFD texture compositing + M15.d HUD overlay/click zones) |
 | M16 | 2D Panel | C | ☐ | — |
 | M17 | MFD Sketchpad 100% | C | ☐ | — |
 | M18 | IAudioBackend + OpenAL | D | ☐ | — |

--- a/OVP/OGLClient/CMakeLists.txt
+++ b/OVP/OGLClient/CMakeLists.txt
@@ -20,6 +20,7 @@ if(NOT WIN32)
 		OGLvVessel.cpp
 		OGLCelSphere.cpp
 		OGLSurface.cpp
+		OGLSketchpad.cpp
 		OGLLaunchpad.cpp
 		OGLTile.cpp
 		OGLParticle.cpp

--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -14,6 +14,7 @@
 #include "OGLMeshRegistry.h"
 #include "OGLScene.h"
 #include "OGLvVessel.h"
+#include "OGLSketchpad.h"
 #include "OGLPostProcess.h"
 #include "OGLParticle.h"
 #include "OGLAnnotation.h"
@@ -43,11 +44,6 @@ namespace ogl {
 static bool FileExists(const char *path) {
 	struct stat st;
 	return stat(path, &st) == 0;
-}
-
-// Helper: convert Orbiter 0xBBGGRR colour to ImGui 0xAABBGGRR (alpha = 0xFF)
-static ImU32 OrbiterColToImU32(DWORD col) {
-	return IM_COL32(col & 0xFF, (col >> 8) & 0xFF, (col >> 16) & 0xFF, 0xFF);
 }
 
 // ============================================================================
@@ -1023,195 +1019,11 @@ bool OGLClient::clbkUseLaunchpadVideoTab() const
 }
 
 // ============================================================================
-// OGL Font / Pen / Brush / Sketchpad — ImGui-backed 2D drawing
+// OGL Font / Pen / Brush / Sketchpad — see OGLSketchpad.{h,cpp}
 // ============================================================================
-
-class OGLFont : public oapi::Font {
-public:
-	ImFont *imFont;
-	float  fontSize;
-	OGLFont(int height, bool prop, const char *face, FontStyle style, int orientation)
-		: oapi::Font(height, prop, face, style, orientation),
-		  imFont(nullptr), fontSize((float)(height < 0 ? -height : height))
-	{
-		ImGuiIO &io = ImGui::GetIO();
-		if (!io.Fonts || io.Fonts->Fonts.Size == 0) return;
-		if (!prop || (face && (strcmp(face, "Fixed") == 0 || strcmp(face, "Courier") == 0 ||
-		              strcmp(face, "Courier New") == 0))) {
-			if (io.Fonts->Fonts.Size > 2) imFont = io.Fonts->Fonts[2];
-			else imFont = io.Fonts->Fonts[0];
-		} else {
-			imFont = io.Fonts->Fonts[0];
-		}
-	}
-};
-
-class OGLPen : public oapi::Pen {
-public:
-	int    style;
-	int    width;
-	ImU32  color;
-	OGLPen(int s, int w, DWORD col) : oapi::Pen(s, w, col), style(s), width(w), color(OrbiterColToImU32(col)) {}
-};
-
-class OGLBrush : public oapi::Brush {
-public:
-	ImU32 color;
-	OGLBrush(DWORD col) : oapi::Brush(col), color(OrbiterColToImU32(col)) {}
-};
-
-class OGLSketchpad : public oapi::Sketchpad {
-public:
-	OGLSketchpad(SURFHANDLE surf, DWORD w, DWORD h)
-		: oapi::Sketchpad(surf), m_dl(nullptr), m_font(nullptr), m_pen(nullptr), m_brush(nullptr),
-		  m_textCol(IM_COL32(255,255,255,255)), m_bgCol(IM_COL32(0,0,0,255)),
-		  m_bkMode(BK_TRANSPARENT), m_tah(LEFT), m_tav(TOP), m_cx(0), m_cy(0),
-		  m_ox(0), m_oy(0), m_viewW(w), m_viewH(h)
-	{
-		m_dl = ImGui::GetForegroundDrawList();
-	}
-
-	oapi::Font *SetFont(oapi::Font *font) override {
-		oapi::Font *prev = m_font; m_font = font; return prev;
-	}
-	oapi::Pen *SetPen(oapi::Pen *pen) override {
-		oapi::Pen *prev = m_pen; m_pen = pen; return prev;
-	}
-	oapi::Brush *SetBrush(oapi::Brush *brush) override {
-		oapi::Brush *prev = m_brush; m_brush = brush; return prev;
-	}
-
-	void SetTextAlign(TAlign_horizontal tah = LEFT, TAlign_vertical tav = TOP) override {
-		m_tah = tah; m_tav = tav;
-	}
-	DWORD SetTextColor(DWORD col) override {
-		DWORD prev = ImGuiColToOrbiter(m_textCol);
-		m_textCol = OrbiterColToImU32(col);
-		return prev;
-	}
-	DWORD SetBackgroundColor(DWORD col) override {
-		DWORD prev = ImGuiColToOrbiter(m_bgCol);
-		m_bgCol = OrbiterColToImU32(col);
-		return prev;
-	}
-	void SetBackgroundMode(BkgMode mode) override { m_bkMode = mode; }
-	void SetOrigin(int x, int y) override { m_ox = x; m_oy = y; }
-	void GetOrigin(int *x, int *y) const override { *x = m_ox; *y = m_oy; }
-
-	DWORD GetCharSize() override {
-		OGLFont *f = static_cast<OGLFont*>(m_font);
-		float sz = f ? f->fontSize : 14.0f;
-		return MAKELONG((int)(sz * 0.6f), (int)sz);
-	}
-
-	DWORD GetTextWidth(const char *str, int len = 0) override {
-		OGLFont *f = static_cast<OGLFont*>(m_font);
-		ImFont *imf = f ? f->imFont : ImGui::GetFont();
-		float sz = f ? f->fontSize : 14.0f;
-		if (!str) return 0;
-		std::string s = (len > 0) ? std::string(str, len) : std::string(str);
-		ImVec2 tsz = imf->CalcTextSizeA(sz, FLT_MAX, 0, s.c_str());
-		return (DWORD)tsz.x;
-	}
-
-	bool Text(int x, int y, const char *str, int len) override {
-		if (!m_dl || !str) return false;
-		OGLFont *f = static_cast<OGLFont*>(m_font);
-		ImFont *imf = f ? f->imFont : ImGui::GetFont();
-		float sz = f ? f->fontSize : 14.0f;
-		std::string s = (len > 0) ? std::string(str, len) : std::string(str);
-		ImVec2 tsz = imf->CalcTextSizeA(sz, FLT_MAX, 0, s.c_str());
-		float dx = (float)(x + m_ox), dy = (float)(y + m_oy);
-		if (m_tah == CENTER) dx -= tsz.x * 0.5f;
-		else if (m_tah == RIGHT) dx -= tsz.x;
-		if (m_tav == BASELINE) dy -= sz * 0.8f;
-		else if (m_tav == BOTTOM) dy -= tsz.y;
-		if (m_bkMode == BK_OPAQUE)
-			m_dl->AddRectFilled(ImVec2(dx, dy), ImVec2(dx + tsz.x, dy + tsz.y), m_bgCol);
-		m_dl->AddText(imf, sz, ImVec2(dx, dy), m_textCol, s.c_str());
-		return true;
-	}
-
-	void MoveTo(int x, int y) override { m_cx = x + m_ox; m_cy = y + m_oy; }
-
-	void LineTo(int x, int y) override {
-		int nx = x + m_ox, ny = y + m_oy;
-		OGLPen *p = static_cast<OGLPen*>(m_pen);
-		if (m_dl && p && p->style != 0)
-			m_dl->AddLine(ImVec2((float)m_cx, (float)m_cy), ImVec2((float)nx, (float)ny),
-			              p->color, (float)std::max(1, p->width));
-		m_cx = nx; m_cy = ny;
-	}
-
-	void Line(int x0, int y0, int x1, int y1) override {
-		OGLPen *p = static_cast<OGLPen*>(m_pen);
-		if (m_dl && p && p->style != 0)
-			m_dl->AddLine(ImVec2((float)(x0+m_ox), (float)(y0+m_oy)),
-			              ImVec2((float)(x1+m_ox), (float)(y1+m_oy)),
-			              p->color, (float)std::max(1, p->width));
-	}
-
-	void Rectangle(int x0, int y0, int x1, int y1) override {
-		if (!m_dl) return;
-		ImVec2 a((float)(x0+m_ox), (float)(y0+m_oy)), b((float)(x1+m_ox), (float)(y1+m_oy));
-		OGLBrush *br = static_cast<OGLBrush*>(m_brush);
-		if (br) m_dl->AddRectFilled(a, b, br->color);
-		OGLPen *p = static_cast<OGLPen*>(m_pen);
-		if (p && p->style != 0) m_dl->AddRect(a, b, p->color, 0, 0, (float)std::max(1, p->width));
-	}
-
-	void Ellipse(int x0, int y0, int x1, int y1) override {
-		if (!m_dl) return;
-		float cx = (x0 + x1) * 0.5f + m_ox, cy = (y0 + y1) * 0.5f + m_oy;
-		float rx = (x1 - x0) * 0.5f, ry = (y1 - y0) * 0.5f;
-		float r = (rx + ry) * 0.5f;
-		OGLBrush *br = static_cast<OGLBrush*>(m_brush);
-		if (br) m_dl->AddCircleFilled(ImVec2(cx, cy), r, br->color);
-		OGLPen *p = static_cast<OGLPen*>(m_pen);
-		if (p && p->style != 0) m_dl->AddCircle(ImVec2(cx, cy), r, p->color, 0, (float)std::max(1, p->width));
-	}
-
-	void Polygon(const oapi::IVECTOR2 *pt, int npt) override {
-		if (!m_dl || npt < 3) return;
-		std::vector<ImVec2> pts(npt);
-		for (int i = 0; i < npt; i++) pts[i] = ImVec2((float)(pt[i].x+m_ox), (float)(pt[i].y+m_oy));
-		OGLBrush *br = static_cast<OGLBrush*>(m_brush);
-		if (br) m_dl->AddConvexPolyFilled(pts.data(), npt, br->color);
-		OGLPen *p = static_cast<OGLPen*>(m_pen);
-		if (p && p->style != 0) m_dl->AddPolyline(pts.data(), npt, p->color, ImDrawFlags_Closed, (float)std::max(1, p->width));
-	}
-
-	void Polyline(const oapi::IVECTOR2 *pt, int npt) override {
-		if (!m_dl || npt < 2) return;
-		OGLPen *p = static_cast<OGLPen*>(m_pen);
-		if (!p || p->style == 0) return;
-		std::vector<ImVec2> pts(npt);
-		for (int i = 0; i < npt; i++) pts[i] = ImVec2((float)(pt[i].x+m_ox), (float)(pt[i].y+m_oy));
-		m_dl->AddPolyline(pts.data(), npt, p->color, 0, (float)std::max(1, p->width));
-	}
-
-	void Pixel(int x, int y, DWORD col) override {
-		if (m_dl) m_dl->AddRectFilled(ImVec2((float)(x+m_ox), (float)(y+m_oy)),
-		                               ImVec2((float)(x+m_ox+1), (float)(y+m_oy+1)),
-		                               OrbiterColToImU32(col));
-	}
-
-private:
-	static DWORD ImGuiColToOrbiter(ImU32 c) {
-		return (c & 0xFF) | ((c >> 8) & 0xFF) << 8 | ((c >> 16) & 0xFF) << 16;
-	}
-	ImDrawList *m_dl;
-	oapi::Font *m_font;
-	oapi::Pen  *m_pen;
-	oapi::Brush *m_brush;
-	ImU32 m_textCol, m_bgCol;
-	BkgMode m_bkMode;
-	TAlign_horizontal m_tah;
-	TAlign_vertical m_tav;
-	int m_cx, m_cy;
-	int m_ox, m_oy;
-	DWORD m_viewW, m_viewH;
-};
+// The concrete classes live in OGLSketchpad.cpp so every MFD draw hits the
+// bound surface's FBO via a dedicated 2D shader. OGLClient just forwards
+// the clbk factory methods.
 
 // --- clbk implementations ---
 
@@ -1241,10 +1053,17 @@ oapi::Brush *OGLClient::clbkCreateBrush(DWORD col) const {
 void OGLClient::clbkReleaseBrush(oapi::Brush *brush) const { delete brush; }
 
 oapi::Sketchpad *OGLClient::clbkGetSketchpad(SURFHANDLE surf) {
+	if (!surf) return nullptr;
 	if (!m_imguiInitialized) return nullptr;
 	if (!ImGui::GetCurrentContext()) return nullptr;
 	if (!ImGui::GetIO().Fonts || !ImGui::GetIO().Fonts->IsBuilt()) return nullptr;
-	return new OGLSketchpad(surf, m_viewW, m_viewH);
+	// Target surface must be an FBO-backed render target; texture-only
+	// surfaces can't accept draw commands. Returning nullptr here matches
+	// the oapi contract: callers must handle the missing sketchpad.
+	OGLSurface *s = (OGLSurface*)surf;
+	if (!s->EnsureFBO()) return nullptr;
+	OGLSketchpad::InitShared(m_shaderMgr);
+	return new OGLSketchpad(surf, m_shaderMgr);
 }
 
 void OGLClient::clbkReleaseSketchpad(oapi::Sketchpad *sp) { delete sp; }

--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -13,6 +13,7 @@
 #include "OGLMaterial.h"
 #include "OGLMeshRegistry.h"
 #include "OGLScene.h"
+#include "OGLvVessel.h"
 #include "OGLPostProcess.h"
 #include "OGLParticle.h"
 #include "OGLAnnotation.h"
@@ -231,6 +232,10 @@ HWND OGLClient::clbkCreateRenderWindow()
 	// Initialize scene
 	m_scene = new OGLScene(m_shaderMgr);
 	m_scene->Init(m_texturePath);
+
+	// Wire the vessel renderer up to this client so the VC pass can reach
+	// GetVCMFDSurface / GetVCHUDSurface through the virtual interface.
+	ogl::OGLvVessel::SetGraphicsClient(this);
 
 	// Initialize blit/panel resources
 	InitBlitResources();

--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -615,11 +615,29 @@ void OGLClient::clbkRender2DPanel(SURFHANDLE *hSurf, MESHHANDLE hMesh, MATRIX3 *
 		MESHGROUPEX *grp = oapiMeshGroupEx(hMesh, g);
 		if (!grp || !grp->nVtx || !grp->nIdx) continue;
 
-		// Bind the texture for this group
+		// UsrFlag bit 2 is Orbiter's "skip this group in the 2D panel pass"
+		// marker — typically used for groups that belong to a different
+		// panel orientation or are geometry placeholders. Matches D3D9Client
+		// (D3D9Client.cpp:1963).
+		if (grp->UsrFlag & 2) continue;
+
+		// Resolve the group's texture. Three cases, matching D3D9's ordering:
+		//   1. TexIdx is in [TEXIDX_MFD0, TEXIDX_MFD0+MAXMFD) → the group is
+		//      an MFD display slot; bind the MFD's painted surface. Without
+		//      this, MFD panels render as uninitialised/garbage indexes.
+		//   2. hSurf provided → lookup into the caller's texture array.
+		//   3. hSurf null → fall back to the mesh's own texture list, with
+		//      oapiGetTextureHandle's 1-based indexing.
 		DWORD texIdx = grp->TexIdx;
 		SURFHANDLE hTex = nullptr;
-		if (texIdx != (DWORD)-1 && hSurf)
+		if (texIdx >= TEXIDX_MFD0 && texIdx < TEXIDX_MFD0 + MAXMFD) {
+			int mfdidx = (int)(texIdx - TEXIDX_MFD0);
+			hTex = GetMFDSurface(mfdidx);
+		} else if (hSurf && texIdx != (DWORD)-1) {
 			hTex = hSurf[texIdx];
+		} else if (texIdx != (DWORD)-1) {
+			hTex = oapiGetTextureHandle(hMesh, texIdx + 1);
+		}
 
 		if (hTex) {
 			OGLSurface *texSurf = (OGLSurface*)hTex;

--- a/OVP/OGLClient/OGLSketchpad.cpp
+++ b/OVP/OGLClient/OGLSketchpad.cpp
@@ -25,6 +25,10 @@ GLint  OGLSketchpad::s_locViewport = -1;
 GLint  OGLSketchpad::s_locColor    = -1;
 GLint  OGLSketchpad::s_locMode     = -1;
 GLint  OGLSketchpad::s_locTexture  = -1;
+GLint  OGLSketchpad::s_locBrightness = -1;
+GLint  OGLSketchpad::s_locColorMat   = -1;
+GLint  OGLSketchpad::s_locGamma      = -1;
+GLint  OGLSketchpad::s_locNoise      = -1;
 bool   OGLSketchpad::s_sharedInitialized = false;
 
 void OGLSketchpad::InitShared(ShaderMgr *sm)
@@ -33,10 +37,14 @@ void OGLSketchpad::InitShared(ShaderMgr *sm)
 	s_sharedInitialized = true;
 
 	s_program = sm->LoadProgram("sketchpad", "sketchpad.vert", "sketchpad.frag");
-	s_locViewport = sm->GetUniformLoc(s_program, "uViewport");
-	s_locColor    = sm->GetUniformLoc(s_program, "uColor");
-	s_locMode     = sm->GetUniformLoc(s_program, "uMode");
-	s_locTexture  = sm->GetUniformLoc(s_program, "uTexture");
+	s_locViewport   = sm->GetUniformLoc(s_program, "uViewport");
+	s_locColor      = sm->GetUniformLoc(s_program, "uColor");
+	s_locMode       = sm->GetUniformLoc(s_program, "uMode");
+	s_locTexture    = sm->GetUniformLoc(s_program, "uTexture");
+	s_locBrightness = sm->GetUniformLoc(s_program, "uBrightness");
+	s_locColorMat   = sm->GetUniformLoc(s_program, "uColorMat");
+	s_locGamma      = sm->GetUniformLoc(s_program, "uGamma");
+	s_locNoise      = sm->GetUniformLoc(s_program, "uNoise");
 
 	// One streaming VBO is enough — every Draw* call rewrites it before the
 	// glDrawArrays, so there is no benefit from separate per-primitive VAOs.
@@ -102,6 +110,18 @@ OGLSketchpad::OGLSketchpad(SURFHANDLE surf, ShaderMgr *sm)
 		m_viewW = m_surf->GetWidth();
 		m_viewH = m_surf->GetHeight();
 	}
+
+	// Identity colour transforms — no visible effect until SetBrightness /
+	// SetColorMatrix / SetRenderParam installs non-default values.
+	m_brightness[0] = m_brightness[1] = m_brightness[2] = m_brightness[3] = 1.0f;
+	for (int i = 0; i < 16; i++) m_colorMat[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+	m_gamma[0] = m_gamma[1] = m_gamma[2] = 1.0f; m_gamma[3] = 0.0f;
+	m_noise[0] = m_noise[1] = m_noise[2] = m_noise[3] = 0.0f;
+	// Shadow starts as identity so a GetColorMatrix before any Set returns
+	// a valid pointer rather than undefined memory.
+	float *m = (float*)&m_colorMatShadow;
+	for (int i = 0; i < 16; i++) m[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+
 	BindState();
 }
 
@@ -129,6 +149,10 @@ void OGLSketchpad::BindState()
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	glUniform2f(s_locViewport, (float)m_viewW, (float)m_viewH);
+	glUniform4fv(s_locBrightness, 1, m_brightness);
+	glUniformMatrix4fv(s_locColorMat, 1, GL_FALSE, m_colorMat);
+	glUniform4fv(s_locGamma, 1, m_gamma);
+	glUniform4fv(s_locNoise, 1, m_noise);
 }
 
 void OGLSketchpad::UnbindState()
@@ -541,6 +565,95 @@ void OGLSketchpad::Pixel(int x, int y, DWORD col)
 		px,        py + 1.0f,
 	};
 	DrawSolidTriangles(tri, 6, col);
+}
+
+// --- Colour transforms -----------------------------------------------------
+
+void OGLSketchpad::SetBrightness(const oapi::FVECTOR4 *pBrightness)
+{
+	if (pBrightness) {
+		m_brightness[0] = pBrightness->x;
+		m_brightness[1] = pBrightness->y;
+		m_brightness[2] = pBrightness->z;
+		m_brightness[3] = pBrightness->w;
+	} else {
+		m_brightness[0] = m_brightness[1] = m_brightness[2] = m_brightness[3] = 1.0f;
+	}
+	if (s_locBrightness >= 0)
+		glUniform4fv(s_locBrightness, 1, m_brightness);
+}
+
+void OGLSketchpad::SetColorMatrix(const oapi::FMATRIX4 *pMatrix)
+{
+	if (pMatrix) {
+		std::memcpy(m_colorMat, pMatrix, sizeof(m_colorMat));
+		m_colorMatShadow = *pMatrix;
+	} else {
+		for (int i = 0; i < 16; i++) m_colorMat[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+		float *m = (float*)&m_colorMatShadow;
+		for (int i = 0; i < 16; i++) m[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+	}
+	if (s_locColorMat >= 0)
+		glUniformMatrix4fv(s_locColorMat, 1, GL_FALSE, m_colorMat);
+}
+
+const oapi::FMATRIX4 *OGLSketchpad::GetColorMatrix()
+{
+	return &m_colorMatShadow;
+}
+
+void OGLSketchpad::SetRenderParam(RenderParam param, const oapi::FVECTOR4 *data)
+{
+	// The oapi::FVECTOR4 layout matches GLSL's vec4; we can forward the
+	// scalars straight through. `data == nullptr` resets that parameter's
+	// effect to the identity.
+	switch (param) {
+	case PRM_GAMMA: {
+		if (data) {
+			// Orbiter passes the gamma exponent in .rgb; shader applies
+			// pow(color, 1/gamma). Invert here so the shader does a plain
+			// pow() per fragment.
+			m_gamma[0] = data->x > 1e-6f ? 1.0f / data->x : 1.0f;
+			m_gamma[1] = data->y > 1e-6f ? 1.0f / data->y : 1.0f;
+			m_gamma[2] = data->z > 1e-6f ? 1.0f / data->z : 1.0f;
+			m_gamma[3] = 0.0f;
+		} else {
+			m_gamma[0] = m_gamma[1] = m_gamma[2] = 1.0f; m_gamma[3] = 0.0f;
+		}
+		if (s_locGamma >= 0)
+			glUniform4fv(s_locGamma, 1, m_gamma);
+		break;
+	}
+	case PRM_NOISE: {
+		if (data) {
+			m_noise[0] = data->x;
+			m_noise[1] = data->y;
+			m_noise[2] = data->z;
+			m_noise[3] = data->w;
+		} else {
+			m_noise[0] = m_noise[1] = m_noise[2] = m_noise[3] = 0.0f;
+		}
+		if (s_locNoise >= 0)
+			glUniform4fv(s_locNoise, 1, m_noise);
+		break;
+	}
+	}
+}
+
+oapi::FVECTOR4 OGLSketchpad::GetRenderParam(RenderParam param)
+{
+	switch (param) {
+	case PRM_GAMMA: {
+		// Shader stores 1/gamma; invert back for the caller.
+		float gx = m_gamma[0] > 1e-6f ? 1.0f / m_gamma[0] : 1.0f;
+		float gy = m_gamma[1] > 1e-6f ? 1.0f / m_gamma[1] : 1.0f;
+		float gz = m_gamma[2] > 1e-6f ? 1.0f / m_gamma[2] : 1.0f;
+		return oapi::FVECTOR4(gx, gy, gz, 0.0f);
+	}
+	case PRM_NOISE:
+		return oapi::FVECTOR4(m_noise[0], m_noise[1], m_noise[2], m_noise[3]);
+	}
+	return oapi::FVECTOR4(0, 0, 0, 0);
 }
 
 } // namespace ogl

--- a/OVP/OGLClient/OGLSketchpad.cpp
+++ b/OVP/OGLClient/OGLSketchpad.cpp
@@ -1,0 +1,548 @@
+// Copyright (c) Martin Schweiger
+// Licensed under the MIT License
+
+#ifndef _WIN32
+
+#include "OGLSketchpad.h"
+#include "OGLShaderMgr.h"
+#include "OGLSurface.h"
+#include "imgui.h"
+#include "imgui_internal.h"   // ImTextCharFromUtf8
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace ogl {
+
+// --- Static shared state ---------------------------------------------------
+
+GLuint OGLSketchpad::s_program = 0;
+GLuint OGLSketchpad::s_vao     = 0;
+GLuint OGLSketchpad::s_vbo     = 0;
+GLint  OGLSketchpad::s_locViewport = -1;
+GLint  OGLSketchpad::s_locColor    = -1;
+GLint  OGLSketchpad::s_locMode     = -1;
+GLint  OGLSketchpad::s_locTexture  = -1;
+bool   OGLSketchpad::s_sharedInitialized = false;
+
+void OGLSketchpad::InitShared(ShaderMgr *sm)
+{
+	if (s_sharedInitialized) return;
+	s_sharedInitialized = true;
+
+	s_program = sm->LoadProgram("sketchpad", "sketchpad.vert", "sketchpad.frag");
+	s_locViewport = sm->GetUniformLoc(s_program, "uViewport");
+	s_locColor    = sm->GetUniformLoc(s_program, "uColor");
+	s_locMode     = sm->GetUniformLoc(s_program, "uMode");
+	s_locTexture  = sm->GetUniformLoc(s_program, "uTexture");
+
+	// One streaming VBO is enough — every Draw* call rewrites it before the
+	// glDrawArrays, so there is no benefit from separate per-primitive VAOs.
+	glGenVertexArrays(1, &s_vao);
+	glGenBuffers(1, &s_vbo);
+	glBindVertexArray(s_vao);
+	glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+	glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)(2 * sizeof(float)));
+	glEnableVertexAttribArray(1);
+	glBindVertexArray(0);
+}
+
+void OGLSketchpad::ReleaseShared()
+{
+	if (!s_sharedInitialized) return;
+	if (s_vao) { glDeleteVertexArrays(1, &s_vao); s_vao = 0; }
+	if (s_vbo) { glDeleteBuffers(1, &s_vbo); s_vbo = 0; }
+	s_program = 0;
+	s_sharedInitialized = false;
+}
+
+// --- Font / Pen / Brush ----------------------------------------------------
+
+OGLFont::OGLFont(int height, bool prop, const char *face,
+                 FontStyle style, int orientation)
+	: oapi::Font(height, prop, face, style, orientation),
+	  imFont(nullptr), fontSize((float)(height < 0 ? -height : height))
+{
+	// Pick from ImGui's built-in atlas. The loader registers three fonts:
+	// index 0 = default proportional, index 2 = fixed-width (if available).
+	// Until we ship our own .ttf pack the face name is only used to swap
+	// between the two buckets.
+	ImGuiIO &io = ImGui::GetIO();
+	if (!io.Fonts || io.Fonts->Fonts.Size == 0) return;
+	const bool wantFixed =
+		!prop ||
+		(face && (!strcmp(face, "Fixed") || !strcmp(face, "Courier") ||
+		          !strcmp(face, "Courier New")));
+	if (wantFixed && io.Fonts->Fonts.Size > 2)
+		imFont = io.Fonts->Fonts[2];
+	else
+		imFont = io.Fonts->Fonts[0];
+}
+
+OGLPen::OGLPen(int s, int w, DWORD c)
+	: oapi::Pen(s, w, c), style(s), width(w < 1 ? 1 : w), col(c) {}
+
+OGLBrush::OGLBrush(DWORD c) : oapi::Brush(c), col(c) {}
+
+// --- Sketchpad ctor/dtor ---------------------------------------------------
+
+OGLSketchpad::OGLSketchpad(SURFHANDLE surf, ShaderMgr *sm)
+	: oapi::Sketchpad(surf), m_surf((OGLSurface*)surf), m_sm(sm),
+	  m_viewW(0), m_viewH(0),
+	  m_font(nullptr), m_pen(nullptr), m_brush(nullptr),
+	  m_textCol(0xFFFFFF), m_bgCol(0x000000),
+	  m_bkMode(BK_TRANSPARENT), m_tah(LEFT), m_tav(TOP),
+	  m_cx(0), m_cy(0), m_ox(0), m_oy(0)
+{
+	if (m_surf) {
+		m_viewW = m_surf->GetWidth();
+		m_viewH = m_surf->GetHeight();
+	}
+	BindState();
+}
+
+OGLSketchpad::~OGLSketchpad()
+{
+	UnbindState();
+}
+
+void OGLSketchpad::BindState()
+{
+	if (!m_surf || !s_program) return;
+
+	// OGLSurface::BindFBO already snapshots the draw/read FBO + viewport
+	// internally and restores them on UnbindFBO. We still save the shader
+	// program, VAO and blend/depth toggles because the caller (e.g. the
+	// scene render path) may rely on those.
+	m_surf->BindFBO();
+
+	glUseProgram(s_program);
+	glBindVertexArray(s_vao);
+
+	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_SCISSOR_TEST);
+	glEnable(GL_BLEND);
+	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+	glUniform2f(s_locViewport, (float)m_viewW, (float)m_viewH);
+}
+
+void OGLSketchpad::UnbindState()
+{
+	if (!m_surf || !s_program) return;
+
+	glBindVertexArray(0);
+	glUseProgram(0);
+	glDisable(GL_BLEND);
+	glEnable(GL_DEPTH_TEST);
+	m_surf->UnbindFBO();
+}
+
+// --- State setters ---------------------------------------------------------
+
+oapi::Font *OGLSketchpad::SetFont(oapi::Font *font) {
+	oapi::Font *prev = m_font; m_font = (OGLFont*)font; return prev;
+}
+
+oapi::Pen *OGLSketchpad::SetPen(oapi::Pen *pen) {
+	oapi::Pen *prev = m_pen; m_pen = (OGLPen*)pen; return prev;
+}
+
+oapi::Brush *OGLSketchpad::SetBrush(oapi::Brush *brush) {
+	oapi::Brush *prev = m_brush; m_brush = (OGLBrush*)brush; return prev;
+}
+
+void OGLSketchpad::SetTextAlign(TAlign_horizontal tah, TAlign_vertical tav) {
+	m_tah = tah; m_tav = tav;
+}
+
+DWORD OGLSketchpad::SetTextColor(DWORD col) {
+	DWORD prev = m_textCol; m_textCol = col; return prev;
+}
+
+DWORD OGLSketchpad::SetBackgroundColor(DWORD col) {
+	DWORD prev = m_bgCol; m_bgCol = col; return prev;
+}
+
+void OGLSketchpad::SetBackgroundMode(BkgMode mode) { m_bkMode = mode; }
+
+void OGLSketchpad::SetOrigin(int x, int y) { m_ox = x; m_oy = y; }
+
+void OGLSketchpad::GetOrigin(int *x, int *y) const {
+	if (x) *x = m_ox;
+	if (y) *y = m_oy;
+}
+
+// --- Metrics ---------------------------------------------------------------
+
+DWORD OGLSketchpad::GetCharSize() {
+	// Orbiter packs (width << 16) | height. We measure against the ImGui
+	// reference glyph so the returned width tracks the actual font.
+	ImFont *imf = m_font ? m_font->imFont : ImGui::GetFont();
+	float sz = m_font ? m_font->fontSize : 14.0f;
+	if (!imf) return ((DWORD)8 << 16) | 14u;
+	ImVec2 ref = imf->CalcTextSizeA(sz, FLT_MAX, 0, "M");
+	DWORD h = (DWORD)std::max(1.0f, sz);
+	DWORD w = (DWORD)std::max(1.0f, ref.x);
+	return (w << 16) | h;
+}
+
+DWORD OGLSketchpad::GetTextWidth(const char *str, int len) {
+	if (!str) return 0;
+	ImFont *imf = m_font ? m_font->imFont : ImGui::GetFont();
+	float sz = m_font ? m_font->fontSize : 14.0f;
+	const char *end = (len > 0) ? str + len : str + std::strlen(str);
+	ImVec2 tsz = imf->CalcTextSizeA(sz, FLT_MAX, 0, str, end);
+	return (DWORD)std::max(0.0f, tsz.x);
+}
+
+// --- Draw helpers ----------------------------------------------------------
+
+void OGLSketchpad::PackColor(DWORD col, float out[4])
+{
+	// Orbiter stores 0xBBGGRR. An alpha byte in bits 24-31 is optional
+	// (D3D9 flagging); zero alpha is treated as fully opaque — this matches
+	// the oapi::ColorCompatibility default every client ships with.
+	float r = ((col >> 16) & 0xFF) / 255.0f;
+	float g = ((col >>  8) & 0xFF) / 255.0f;
+	float b = ( col        & 0xFF) / 255.0f;
+	float a = ((col >> 24) & 0xFF) / 255.0f;
+	if (a < 1.0f / 255.0f) a = 1.0f;
+	out[0] = r; out[1] = g; out[2] = b; out[3] = a;
+}
+
+void OGLSketchpad::DrawSolidTriangles(const float *xy, int nVerts, DWORD col)
+{
+	if (!xy || nVerts < 3) return;
+	std::vector<float> verts(nVerts * 4, 0.0f);
+	for (int i = 0; i < nVerts; i++) {
+		verts[i * 4 + 0] = xy[i * 2 + 0];
+		verts[i * 4 + 1] = xy[i * 2 + 1];
+	}
+	float c[4]; PackColor(col, c);
+	glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+	glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(float), verts.data(), GL_STREAM_DRAW);
+	glUniform4fv(s_locColor, 1, c);
+	glUniform1i(s_locMode, MODE_SOLID);
+	glDrawArrays(GL_TRIANGLES, 0, nVerts);
+}
+
+void OGLSketchpad::DrawSolidLines(const float *xy, int nVerts, DWORD col, int width)
+{
+	if (!xy || nVerts < 2) return;
+	std::vector<float> verts(nVerts * 4, 0.0f);
+	for (int i = 0; i < nVerts; i++) {
+		verts[i * 4 + 0] = xy[i * 2 + 0];
+		verts[i * 4 + 1] = xy[i * 2 + 1];
+	}
+	float c[4]; PackColor(col, c);
+	glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+	glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(float), verts.data(), GL_STREAM_DRAW);
+	glUniform4fv(s_locColor, 1, c);
+	glUniform1i(s_locMode, MODE_SOLID);
+	glLineWidth((float)std::max(1, width));
+	glDrawArrays(GL_LINES, 0, nVerts);
+}
+
+// Expand a polyline into a triangle strip so thick lines render correctly
+// even where glLineWidth clamps at 1.0 (macOS Core Profile does). Each
+// interior segment produces two triangles; joins use a plain miter at
+// the segment midpoint, which matches D3D9Pad's "flat join" default and is
+// visually indistinguishable at MFD-sized pen widths (≤ 3 px).
+void OGLSketchpad::DrawStrokedPolyline(const float *xy, int nVerts, DWORD col,
+                                       int width, bool closed)
+{
+	if (!xy || nVerts < 2) return;
+	if (width <= 1) {
+		// Fast path: just glLineWidth(1) line strip / loop.
+		std::vector<float> verts(nVerts * 4, 0.0f);
+		for (int i = 0; i < nVerts; i++) {
+			verts[i * 4 + 0] = xy[i * 2 + 0];
+			verts[i * 4 + 1] = xy[i * 2 + 1];
+		}
+		float c[4]; PackColor(col, c);
+		glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+		glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(float), verts.data(), GL_STREAM_DRAW);
+		glUniform4fv(s_locColor, 1, c);
+		glUniform1i(s_locMode, MODE_SOLID);
+		glLineWidth(1.0f);
+		glDrawArrays(closed ? GL_LINE_LOOP : GL_LINE_STRIP, 0, nVerts);
+		return;
+	}
+
+	// Thick path: emit two triangles per segment. Segment extents are
+	// normalised and rotated 90° to give the perpendicular half-width.
+	const float halfW = width * 0.5f;
+	std::vector<float> tri;
+	tri.reserve((nVerts + (closed ? 1 : 0)) * 6 * 4);
+
+	const int nSeg = closed ? nVerts : nVerts - 1;
+	for (int i = 0; i < nSeg; i++) {
+		const float x0 = xy[(i * 2) + 0];
+		const float y0 = xy[(i * 2) + 1];
+		const int   j  = (i + 1) % nVerts;
+		const float x1 = xy[(j * 2) + 0];
+		const float y1 = xy[(j * 2) + 1];
+
+		const float dx = x1 - x0, dy = y1 - y0;
+		const float len = std::sqrt(dx * dx + dy * dy);
+		if (len < 1e-5f) continue;
+		const float nx = -dy / len * halfW;
+		const float ny =  dx / len * halfW;
+
+		// Quad corners: a0-a1-b1, a0-b1-b0.
+		const float a0x = x0 + nx, a0y = y0 + ny;
+		const float a1x = x0 - nx, a1y = y0 - ny;
+		const float b0x = x1 + nx, b0y = y1 + ny;
+		const float b1x = x1 - nx, b1y = y1 - ny;
+
+		tri.insert(tri.end(), { a0x, a0y, 0, 0, a1x, a1y, 0, 0, b1x, b1y, 0, 0,
+		                        a0x, a0y, 0, 0, b1x, b1y, 0, 0, b0x, b0y, 0, 0 });
+	}
+	if (tri.empty()) return;
+
+	float c[4]; PackColor(col, c);
+	glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+	glBufferData(GL_ARRAY_BUFFER, tri.size() * sizeof(float), tri.data(), GL_STREAM_DRAW);
+	glUniform4fv(s_locColor, 1, c);
+	glUniform1i(s_locMode, MODE_SOLID);
+	glDrawArrays(GL_TRIANGLES, 0, (GLsizei)(tri.size() / 4));
+}
+
+void OGLSketchpad::DrawTexturedQuads(const float *xyuv, int nVerts,
+                                     GLuint tex, DWORD col, Mode mode)
+{
+	if (!xyuv || nVerts < 3 || !tex) return;
+	float c[4]; PackColor(col, c);
+	glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+	glBufferData(GL_ARRAY_BUFFER, nVerts * 4 * sizeof(float), xyuv, GL_STREAM_DRAW);
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, tex);
+	glUniform1i(s_locTexture, 0);
+	glUniform4fv(s_locColor, 1, c);
+	glUniform1i(s_locMode, mode);
+	glDrawArrays(GL_TRIANGLES, 0, nVerts);
+}
+
+// --- Primitives ------------------------------------------------------------
+
+bool OGLSketchpad::Text(int x, int y, const char *str, int len)
+{
+	if (!str || !s_program) return false;
+	ImFont *imf = m_font ? m_font->imFont : ImGui::GetFont();
+	float   sz  = m_font ? m_font->fontSize : 14.0f;
+	if (!imf) return false;
+
+	const char *end = (len > 0) ? str + len : str + std::strlen(str);
+	ImVec2 tsz = imf->CalcTextSizeA(sz, FLT_MAX, 0, str, end);
+
+	float px = (float)(x + m_ox);
+	float py = (float)(y + m_oy);
+	if (m_tah == CENTER) px -= tsz.x * 0.5f;
+	else if (m_tah == RIGHT) px -= tsz.x;
+	if (m_tav == BASELINE) py -= sz * 0.8f;
+	else if (m_tav == BOTTOM) py -= tsz.y;
+
+	if (m_bkMode == BK_OPAQUE) {
+		const float r[2 * 3 * 2] = {
+			px,         py,
+			px + tsz.x, py,
+			px,         py + tsz.y,
+			px + tsz.x, py,
+			px + tsz.x, py + tsz.y,
+			px,         py + tsz.y,
+		};
+		DrawSolidTriangles(r, 6, m_bgCol);
+	}
+
+	// ImGui 1.92 bakes glyph metrics per requested size; we fetch the baked
+	// entry for `sz` so glyph->X0..AdvanceX come back already scaled and do
+	// not need a per-glyph multiply at draw time. The atlas texture id is
+	// exposed via ImFontAtlas::TexRef; nullptr IDs happen transiently while
+	// a dynamic atlas rebuilds.
+	ImFontAtlas   *atlas  = ImGui::GetIO().Fonts;
+	GLuint         atlasTex = atlas ? (GLuint)(std::uintptr_t)atlas->TexRef.GetTexID() : 0;
+	ImFontBaked   *baked  = imf->GetFontBaked(sz);
+	if (!atlasTex || !baked) return true;
+
+	float pen = px;
+	std::vector<float> quads;
+	quads.reserve((end - str) * 6 * 4);
+
+	for (const char *p = str; p < end; ) {
+		unsigned int codepoint = 0;
+		int bytes = ImTextCharFromUtf8(&codepoint, p, end);
+		if (bytes <= 0) break;
+		p += bytes;
+
+		ImFontGlyph *glyph = baked->FindGlyph((ImWchar)codepoint);
+		if (!glyph) continue;
+
+		float gx0 = pen + glyph->X0;
+		float gy0 = py  + glyph->Y0;
+		float gx1 = pen + glyph->X1;
+		float gy1 = py  + glyph->Y1;
+
+		quads.insert(quads.end(), {
+			gx0, gy0, glyph->U0, glyph->V0,
+			gx1, gy0, glyph->U1, glyph->V0,
+			gx0, gy1, glyph->U0, glyph->V1,
+			gx1, gy0, glyph->U1, glyph->V0,
+			gx1, gy1, glyph->U1, glyph->V1,
+			gx0, gy1, glyph->U0, glyph->V1,
+		});
+		pen += glyph->AdvanceX;
+	}
+
+	if (!quads.empty()) {
+		DrawTexturedQuads(quads.data(), (int)(quads.size() / 4),
+		                  atlasTex, m_textCol, MODE_TEXT);
+	}
+	return true;
+}
+
+void OGLSketchpad::MoveTo(int x, int y) { m_cx = x + m_ox; m_cy = y + m_oy; }
+
+void OGLSketchpad::LineTo(int x, int y)
+{
+	if (!m_pen || m_pen->style == 0) { m_cx = x + m_ox; m_cy = y + m_oy; return; }
+	const int nx = x + m_ox, ny = y + m_oy;
+	const float line[4] = { (float)m_cx, (float)m_cy, (float)nx, (float)ny };
+	DrawStrokedPolyline(line, 2, m_pen->col, m_pen->width, false);
+	m_cx = nx; m_cy = ny;
+}
+
+void OGLSketchpad::Line(int x0, int y0, int x1, int y1)
+{
+	if (!m_pen || m_pen->style == 0) return;
+	const float line[4] = {
+		(float)(x0 + m_ox), (float)(y0 + m_oy),
+		(float)(x1 + m_ox), (float)(y1 + m_oy),
+	};
+	DrawStrokedPolyline(line, 2, m_pen->col, m_pen->width, false);
+}
+
+void OGLSketchpad::Rectangle(int x0, int y0, int x1, int y1)
+{
+	if (x0 == x1 || y0 == y1) return;
+	float ax = (float)(x0 + m_ox), ay = (float)(y0 + m_oy);
+	float bx = (float)(x1 + m_ox), by = (float)(y1 + m_oy);
+	if (ax > bx) std::swap(ax, bx);
+	if (ay > by) std::swap(ay, by);
+
+	if (m_brush) {
+		const float tri[6 * 2] = {
+			ax, ay, bx, ay, ax, by,
+			bx, ay, bx, by, ax, by,
+		};
+		DrawSolidTriangles(tri, 6, m_brush->col);
+	}
+	if (m_pen && m_pen->style != 0) {
+		const float loop[4 * 2] = { ax, ay, bx, ay, bx, by, ax, by };
+		DrawStrokedPolyline(loop, 4, m_pen->col, m_pen->width, true);
+	}
+}
+
+void OGLSketchpad::Ellipse(int x0, int y0, int x1, int y1)
+{
+	if (x0 == x1 || y0 == y1) return;
+	float ax = (float)(x0 + m_ox), ay = (float)(y0 + m_oy);
+	float bx = (float)(x1 + m_ox), by = (float)(y1 + m_oy);
+	if (ax > bx) std::swap(ax, bx);
+	if (ay > by) std::swap(ay, by);
+	const float cx = (ax + bx) * 0.5f;
+	const float cy = (ay + by) * 0.5f;
+	const float rx = (bx - ax) * 0.5f;
+	const float ry = (by - ay) * 0.5f;
+
+	// Pick segment count from the larger radius so circles and extreme
+	// ellipses both look smooth without over-tesselating small glyphs.
+	const float rMax = std::max(rx, ry);
+	int nSeg = (int)std::max(8.0f, std::min(96.0f, 8.0f + rMax * 0.6f));
+
+	std::vector<float> pts(nSeg * 2);
+	for (int i = 0; i < nSeg; i++) {
+		float a = (float)i / (float)nSeg * 2.0f * (float)M_PI;
+		pts[i * 2 + 0] = cx + std::cos(a) * rx;
+		pts[i * 2 + 1] = cy + std::sin(a) * ry;
+	}
+
+	if (m_brush) {
+		// Triangle fan around the centre.
+		std::vector<float> tri;
+		tri.reserve(nSeg * 3 * 2);
+		for (int i = 0; i < nSeg; i++) {
+			int j = (i + 1) % nSeg;
+			tri.insert(tri.end(), {
+				cx, cy,
+				pts[i * 2 + 0], pts[i * 2 + 1],
+				pts[j * 2 + 0], pts[j * 2 + 1],
+			});
+		}
+		DrawSolidTriangles(tri.data(), (int)(tri.size() / 2), m_brush->col);
+	}
+	if (m_pen && m_pen->style != 0) {
+		DrawStrokedPolyline(pts.data(), nSeg, m_pen->col, m_pen->width, true);
+	}
+}
+
+void OGLSketchpad::Polygon(const oapi::IVECTOR2 *pt, int npt)
+{
+	if (!pt || npt < 3) return;
+	std::vector<float> pts(npt * 2);
+	for (int i = 0; i < npt; i++) {
+		pts[i * 2 + 0] = (float)(pt[i].x + m_ox);
+		pts[i * 2 + 1] = (float)(pt[i].y + m_oy);
+	}
+	if (m_brush) {
+		// Fan from vertex 0. Works for convex inputs; Orbiter's MFD code
+		// uses Polygon for strictly convex glyph fills so this is safe.
+		std::vector<float> tri;
+		tri.reserve((npt - 2) * 3 * 2);
+		for (int i = 1; i < npt - 1; i++) {
+			tri.insert(tri.end(), {
+				pts[0], pts[1],
+				pts[i * 2 + 0], pts[i * 2 + 1],
+				pts[(i + 1) * 2 + 0], pts[(i + 1) * 2 + 1],
+			});
+		}
+		if (!tri.empty())
+			DrawSolidTriangles(tri.data(), (int)(tri.size() / 2), m_brush->col);
+	}
+	if (m_pen && m_pen->style != 0) {
+		DrawStrokedPolyline(pts.data(), npt, m_pen->col, m_pen->width, true);
+	}
+}
+
+void OGLSketchpad::Polyline(const oapi::IVECTOR2 *pt, int npt)
+{
+	if (!pt || npt < 2 || !m_pen || m_pen->style == 0) return;
+	std::vector<float> pts(npt * 2);
+	for (int i = 0; i < npt; i++) {
+		pts[i * 2 + 0] = (float)(pt[i].x + m_ox);
+		pts[i * 2 + 1] = (float)(pt[i].y + m_oy);
+	}
+	DrawStrokedPolyline(pts.data(), npt, m_pen->col, m_pen->width, false);
+}
+
+void OGLSketchpad::Pixel(int x, int y, DWORD col)
+{
+	const float px = (float)(x + m_ox), py = (float)(y + m_oy);
+	const float tri[6 * 2] = {
+		px,        py,
+		px + 1.0f, py,
+		px,        py + 1.0f,
+		px + 1.0f, py,
+		px + 1.0f, py + 1.0f,
+		px,        py + 1.0f,
+	};
+	DrawSolidTriangles(tri, 6, col);
+}
+
+} // namespace ogl
+
+#endif // !_WIN32

--- a/OVP/OGLClient/OGLSketchpad.cpp
+++ b/OVP/OGLClient/OGLSketchpad.cpp
@@ -31,6 +31,11 @@ GLint  OGLSketchpad::s_locGamma      = -1;
 GLint  OGLSketchpad::s_locNoise      = -1;
 GLint  OGLSketchpad::s_locColor2     = -1;
 GLint  OGLSketchpad::s_locColorKey   = -1;
+GLint  OGLSketchpad::s_locWorld      = -1;
+GLint  OGLSketchpad::s_locViewProj   = -1;
+GLint  OGLSketchpad::s_locViewMode   = -1;
+GLint  OGLSketchpad::s_locClipperDir = -1;
+GLint  OGLSketchpad::s_locClipperCosDist = -1;
 bool   OGLSketchpad::s_sharedInitialized = false;
 
 void OGLSketchpad::InitShared(ShaderMgr *sm)
@@ -49,6 +54,11 @@ void OGLSketchpad::InitShared(ShaderMgr *sm)
 	s_locNoise      = sm->GetUniformLoc(s_program, "uNoise");
 	s_locColor2     = sm->GetUniformLoc(s_program, "uColor2");
 	s_locColorKey   = sm->GetUniformLoc(s_program, "uColorKey");
+	s_locWorld      = sm->GetUniformLoc(s_program, "uWorld");
+	s_locViewProj   = sm->GetUniformLoc(s_program, "uViewProj");
+	s_locViewMode   = sm->GetUniformLoc(s_program, "uViewMode");
+	s_locClipperDir     = sm->GetUniformLoc(s_program, "uClipperDir[0]");
+	s_locClipperCosDist = sm->GetUniformLoc(s_program, "uClipperCosDist[0]");
 
 	// One streaming VBO is enough — every Draw* call rewrites it before the
 	// glDrawArrays, so there is no benefit from separate per-primitive VAOs.
@@ -129,6 +139,30 @@ OGLSketchpad::OGLSketchpad(SURFHANDLE surf, ShaderMgr *sm)
 	float *m = (float*)&m_colorMatShadow;
 	for (int i = 0; i < 16; i++) m[i] = (i % 5 == 0) ? 1.0f : 0.0f;
 
+	// Transform + view/proj state defaults to identity / ORTHO so pre-M17.d
+	// callers see no behavioural change.
+	for (int i = 0; i < 16; i++) {
+		m_world[i]    = (i % 5 == 0) ? 1.0f : 0.0f;
+		m_view[i]     = (i % 5 == 0) ? 1.0f : 0.0f;
+		m_proj[i]     = (i % 5 == 0) ? 1.0f : 0.0f;
+		m_viewProj[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+	}
+	float *vs = (float*)&m_viewShadow;
+	float *ps = (float*)&m_projShadow;
+	float *vps = (float*)&m_viewProjShadow;
+	for (int i = 0; i < 16; i++) {
+		vs[i] = ps[i] = vps[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+	}
+	m_viewMode = ORTHO;
+	m_clipNear = 0.1f;
+	m_clipFar  = 1000.0f;
+	for (int i = 0; i < 2; i++) {
+		m_clipperDir[i][0] = m_clipperDir[i][1] = m_clipperDir[i][2] = 0.0f;
+		m_clipperDir[i][3] = 0.0f;   // disabled
+		m_clipperCosDist[i][0] = 1.0f;
+		m_clipperCosDist[i][1] = 0.0f;
+	}
+
 	BindState();
 }
 
@@ -168,6 +202,25 @@ void OGLSketchpad::BindState()
 	const float off[4] = { 0, 0, 0, 0 };
 	glUniform4fv(s_locColor2, 1, off);
 	glUniform4fv(s_locColorKey, 1, off);
+
+	// Transform + projection state.
+	glUniformMatrix4fv(s_locWorld,    1, GL_FALSE, m_world);
+	glUniformMatrix4fv(s_locViewProj, 1, GL_FALSE, m_viewProj);
+	glUniform1i       (s_locViewMode, m_viewMode);
+
+	// Clipper slots default to disabled.
+	float dir[8]     = { 0,0,0,0, 0,0,0,0 };
+	float cosdist[4] = { 1,0, 1,0 };
+	for (int i = 0; i < 2; i++) {
+		dir[i*4 + 0] = m_clipperDir[i][0];
+		dir[i*4 + 1] = m_clipperDir[i][1];
+		dir[i*4 + 2] = m_clipperDir[i][2];
+		dir[i*4 + 3] = m_clipperDir[i][3];
+		cosdist[i*2 + 0] = m_clipperCosDist[i][0];
+		cosdist[i*2 + 1] = m_clipperCosDist[i][1];
+	}
+	glUniform4fv(s_locClipperDir,     2, dir);
+	glUniform2fv(s_locClipperCosDist, 2, cosdist);
 }
 
 void OGLSketchpad::UnbindState()
@@ -995,6 +1048,267 @@ void OGLSketchpad::StretchRegion(const skpRegion *rgn, const SURFHANDLE hSrc,
 	stretch(ir, it, sr, ib, tiR, tiT, tr,  tiB);
 	// centre
 	stretch(il, it, ir, ib, tiL, tiT, tiR, tiB);
+}
+
+// --- Transform state ------------------------------------------------------
+
+static inline void MakeIdentity(float m[16])
+{
+	for (int i = 0; i < 16; i++) m[i] = (i % 5 == 0) ? 1.0f : 0.0f;
+}
+
+static inline void Mul4x4(const float a[16], const float b[16], float out[16])
+{
+	// Column-major 4x4 multiply (same layout oapi::FMATRIX4 uses on disk).
+	float tmp[16];
+	for (int c = 0; c < 4; c++)
+		for (int r = 0; r < 4; r++) {
+			float s = 0.0f;
+			for (int k = 0; k < 4; k++) s += a[k * 4 + r] * b[c * 4 + k];
+			tmp[c * 4 + r] = s;
+		}
+	std::memcpy(out, tmp, sizeof(tmp));
+}
+
+void OGLSketchpad::SetWorldTransform(const oapi::FMATRIX4 *pWT)
+{
+	if (pWT) std::memcpy(m_world, pWT, sizeof(m_world));
+	else     MakeIdentity(m_world);
+	if (s_locWorld >= 0)
+		glUniformMatrix4fv(s_locWorld, 1, GL_FALSE, m_world);
+}
+
+void OGLSketchpad::SetWorldTransform2D(float scale, float rot,
+                                       const oapi::IVECTOR2 *ctr,
+                                       const oapi::IVECTOR2 *trl)
+{
+	// Compose T(translation) * T(centre) * R(rot) * S(scale) * T(-centre).
+	// Matches the D3D9Pad2 reference so 2D panel callers that mix
+	// SetWorldTransform2D and SetOrigin see identical geometry.
+	const float cx = ctr ? (float)ctr->x : 0.0f;
+	const float cy = ctr ? (float)ctr->y : 0.0f;
+	const float tx = trl ? (float)trl->x : 0.0f;
+	const float ty = trl ? (float)trl->y : 0.0f;
+	const float c  = std::cos(rot);
+	const float s  = std::sin(rot);
+
+	float m[16];
+	MakeIdentity(m);
+	// column-major 4x4: composite 2D affine in the xy plane.
+	m[0 * 4 + 0] =  c * scale;
+	m[0 * 4 + 1] =  s * scale;
+	m[1 * 4 + 0] = -s * scale;
+	m[1 * 4 + 1] =  c * scale;
+	m[3 * 4 + 0] = tx + cx - (c * scale * cx - s * scale * cy);
+	m[3 * 4 + 1] = ty + cy - (s * scale * cx + c * scale * cy);
+
+	std::memcpy(m_world, m, sizeof(m_world));
+	if (s_locWorld >= 0)
+		glUniformMatrix4fv(s_locWorld, 1, GL_FALSE, m_world);
+}
+
+oapi::FMATRIX4 OGLSketchpad::GetWorldTransform() const
+{
+	oapi::FMATRIX4 out;
+	std::memcpy(&out, m_world, sizeof(m_world));
+	return out;
+}
+
+void OGLSketchpad::PushWorldTransform()
+{
+	std::array<float, 16> snap;
+	std::memcpy(snap.data(), m_world, sizeof(m_world));
+	m_worldStack.push_back(snap);
+}
+
+void OGLSketchpad::PopWorldTransform()
+{
+	if (m_worldStack.empty()) return;
+	std::memcpy(m_world, m_worldStack.back().data(), sizeof(m_world));
+	m_worldStack.pop_back();
+	if (s_locWorld >= 0)
+		glUniformMatrix4fv(s_locWorld, 1, GL_FALSE, m_world);
+}
+
+// --- View / projection ----------------------------------------------------
+
+void OGLSketchpad::SetViewMatrix(const oapi::FMATRIX4 *pV)
+{
+	if (pV) { std::memcpy(m_view, pV, sizeof(m_view)); m_viewShadow = *pV; }
+	else    { MakeIdentity(m_view); float *m = (float*)&m_viewShadow;
+	          for (int i = 0; i < 16; i++) m[i] = (i % 5 == 0) ? 1.0f : 0.0f; }
+	Mul4x4(m_view, m_proj, m_viewProj);
+	std::memcpy(&m_viewProjShadow, m_viewProj, sizeof(m_viewProj));
+	if (s_locViewProj >= 0)
+		glUniformMatrix4fv(s_locViewProj, 1, GL_FALSE, m_viewProj);
+}
+
+void OGLSketchpad::SetProjectionMatrix(const oapi::FMATRIX4 *pP)
+{
+	if (pP) { std::memcpy(m_proj, pP, sizeof(m_proj)); m_projShadow = *pP; }
+	else    { MakeIdentity(m_proj); float *m = (float*)&m_projShadow;
+	          for (int i = 0; i < 16; i++) m[i] = (i % 5 == 0) ? 1.0f : 0.0f; }
+	Mul4x4(m_view, m_proj, m_viewProj);
+	std::memcpy(&m_viewProjShadow, m_viewProj, sizeof(m_viewProj));
+	if (s_locViewProj >= 0)
+		glUniformMatrix4fv(s_locViewProj, 1, GL_FALSE, m_viewProj);
+}
+
+const oapi::FMATRIX4 *OGLSketchpad::ViewMatrix() const { return &m_viewShadow; }
+const oapi::FMATRIX4 *OGLSketchpad::ProjectionMatrix() const { return &m_projShadow; }
+const oapi::FMATRIX4 *OGLSketchpad::GetViewProjectionMatrix() const { return &m_viewProjShadow; }
+
+void OGLSketchpad::SetViewMode(SkpView mode)
+{
+	m_viewMode = mode;
+	if (s_locViewMode >= 0)
+		glUniform1i(s_locViewMode, m_viewMode);
+}
+
+// --- Clipping -------------------------------------------------------------
+
+void OGLSketchpad::ClipRect(const LPRECT pClip)
+{
+	if (pClip) {
+		// glScissor uses bottom-left origin; Sketchpad uses top-left. Flip
+		// y against the target surface height.
+		int x = pClip->left;
+		int y = (int)m_viewH - pClip->bottom;
+		int w = pClip->right  - pClip->left;
+		int h = pClip->bottom - pClip->top;
+		glEnable(GL_SCISSOR_TEST);
+		glScissor(x, y, std::max(0, w), std::max(0, h));
+	} else {
+		glDisable(GL_SCISSOR_TEST);
+	}
+}
+
+void OGLSketchpad::Clipper(int idx, const VECTOR3 *pPos,
+                           double cos_angle, double dist)
+{
+	if (idx < 0 || idx > 1) return;
+	if (pPos) {
+		const double l = std::sqrt(pPos->x * pPos->x + pPos->y * pPos->y + pPos->z * pPos->z);
+		const double inv = l > 1e-9 ? 1.0 / l : 0.0;
+		m_clipperDir[idx][0] = (float)(pPos->x * inv);
+		m_clipperDir[idx][1] = (float)(pPos->y * inv);
+		m_clipperDir[idx][2] = (float)(pPos->z * inv);
+		m_clipperDir[idx][3] = 1.0f;
+		m_clipperCosDist[idx][0] = (float)cos_angle;
+		m_clipperCosDist[idx][1] = (float)dist;
+	} else {
+		m_clipperDir[idx][3] = 0.0f;  // disabled
+	}
+	// Re-upload the whole pair so we don't have to track per-slot array
+	// uniform offsets.
+	float dir[8], cd[4];
+	for (int i = 0; i < 2; i++) {
+		dir[i*4 + 0] = m_clipperDir[i][0];
+		dir[i*4 + 1] = m_clipperDir[i][1];
+		dir[i*4 + 2] = m_clipperDir[i][2];
+		dir[i*4 + 3] = m_clipperDir[i][3];
+		cd[i*2 + 0]  = m_clipperCosDist[i][0];
+		cd[i*2 + 1]  = m_clipperCosDist[i][1];
+	}
+	if (s_locClipperDir     >= 0) glUniform4fv(s_locClipperDir,     2, dir);
+	if (s_locClipperCosDist >= 0) glUniform2fv(s_locClipperCosDist, 2, cd);
+}
+
+void OGLSketchpad::SetClipDistance(float _near, float _far)
+{
+	m_clipNear = _near;
+	m_clipFar  = _far;
+	// glDepthRangef in Core Profile can't change near/far clip planes on
+	// its own; those are baked into the projection matrix. We store the
+	// values so future SetProjectionMatrix calls (or USER-mode defaults)
+	// can read them; nothing in the shipping MFDs/plugins calls this
+	// outside of USER mode with a custom projection, where the caller
+	// builds the matrix themselves.
+}
+
+// --- Metrics --------------------------------------------------------------
+
+void OGLSketchpad::GetRenderSurfaceSize(LPSIZE size)
+{
+	if (!size) return;
+	size->cx = (LONG)m_viewW;
+	size->cy = (LONG)m_viewH;
+}
+
+// --- World-space primitives ----------------------------------------------
+
+int OGLSketchpad::DrawMeshGroup(const MESHHANDLE hMesh, DWORD grp,
+                                MeshFlags flags, const SURFHANDLE hTex)
+{
+	if (!hMesh) return -1;
+	MESHGROUPEX *g = oapiMeshGroupEx(hMesh, grp);
+	if (!g || !g->Vtx || !g->Idx || g->nIdx < 3) return -1;
+
+	// Build an interleaved [x,y,u,v] stream. Meshes intended for the
+	// Sketchpad path typically place data in the xy plane; we drop z so
+	// the existing 2D VBO layout fits.
+	std::vector<float> verts(g->nIdx * 4);
+	for (DWORD i = 0; i < g->nIdx; i++) {
+		const NTVERTEX &v = g->Vtx[g->Idx[i]];
+		verts[i * 4 + 0] = v.x;
+		verts[i * 4 + 1] = v.y;
+		verts[i * 4 + 2] = v.tu;
+		verts[i * 4 + 3] = v.tv;
+	}
+
+	glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+	glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(float),
+	             verts.data(), GL_STREAM_DRAW);
+
+	if (hTex) {
+		OGLSurface *ts = (OGLSurface*)hTex;
+		glActiveTexture(GL_TEXTURE0);
+		glBindTexture(GL_TEXTURE_2D, ts->GetTexture());
+		glUniform1i(s_locTexture, 0);
+		const float white[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+		glUniform4fv(s_locColor, 1, white);
+		glUniform1i(s_locMode, MODE_TEXTURE);
+	} else {
+		float c[4]; PackColor(m_brush ? m_brush->col : 0xFFFFFF, c);
+		glUniform4fv(s_locColor, 1, c);
+		glUniform1i(s_locMode, MODE_SOLID);
+	}
+
+	(void)flags;  // SMOOTH_SHADE / CULL_NONE don't affect 2D Sketchpad output
+	glDrawArrays(GL_TRIANGLES, 0, (GLsizei)g->nIdx);
+	return (int)g->nIdx;
+}
+
+// HPOLY is an opaque Orbiter handle for pre-baked polygon geometry.
+// clbkCreatePoly (GraphicsAPI.h) returns client-specific concrete types;
+// OGLClient does not currently implement that factory, so no HPOLY that
+// reaches here would have been produced by us. Accept the handle and
+// draw nothing — calling code with a null-handle fallback will see a
+// no-op rather than an assert, which matches the "polygon not baked"
+// behaviour D3D9 exhibits when clbkCreatePoly returns NULL.
+void OGLSketchpad::DrawPoly(const HPOLY /*hPoly*/, DWORD /*flags*/) {}
+
+void OGLSketchpad::SetWorldBillboard(const oapi::FVECTOR3 &wpos, float scl,
+                                     bool /*bFixed*/,
+                                     const oapi::FVECTOR3 * /*index*/)
+{
+	// Build a billboard world matrix that translates to `wpos` and
+	// applies a uniform scale. The caller is responsible for installing
+	// an appropriate view + projection beforehand (USER mode); we leave
+	// orientation axis-aligned — the `index` override is an advanced
+	// customisation D3D9Pad uses for fixed-axis billboards and is not
+	// exercised by any shipping caller.
+	float m[16];
+	MakeIdentity(m);
+	m[0 * 4 + 0] = scl;
+	m[1 * 4 + 1] = scl;
+	m[2 * 4 + 2] = scl;
+	m[3 * 4 + 0] = wpos.x;
+	m[3 * 4 + 1] = wpos.y;
+	m[3 * 4 + 2] = wpos.z;
+	std::memcpy(m_world, m, sizeof(m_world));
+	if (s_locWorld >= 0)
+		glUniformMatrix4fv(s_locWorld, 1, GL_FALSE, m_world);
 }
 
 // --- Misc primitives -------------------------------------------------------

--- a/OVP/OGLClient/OGLSketchpad.cpp
+++ b/OVP/OGLClient/OGLSketchpad.cpp
@@ -29,6 +29,8 @@ GLint  OGLSketchpad::s_locBrightness = -1;
 GLint  OGLSketchpad::s_locColorMat   = -1;
 GLint  OGLSketchpad::s_locGamma      = -1;
 GLint  OGLSketchpad::s_locNoise      = -1;
+GLint  OGLSketchpad::s_locColor2     = -1;
+GLint  OGLSketchpad::s_locColorKey   = -1;
 bool   OGLSketchpad::s_sharedInitialized = false;
 
 void OGLSketchpad::InitShared(ShaderMgr *sm)
@@ -45,6 +47,8 @@ void OGLSketchpad::InitShared(ShaderMgr *sm)
 	s_locColorMat   = sm->GetUniformLoc(s_program, "uColorMat");
 	s_locGamma      = sm->GetUniformLoc(s_program, "uGamma");
 	s_locNoise      = sm->GetUniformLoc(s_program, "uNoise");
+	s_locColor2     = sm->GetUniformLoc(s_program, "uColor2");
+	s_locColorKey   = sm->GetUniformLoc(s_program, "uColorKey");
 
 	// One streaming VBO is enough — every Draw* call rewrites it before the
 	// glDrawArrays, so there is no benefit from separate per-primitive VAOs.
@@ -104,7 +108,10 @@ OGLSketchpad::OGLSketchpad(SURFHANDLE surf, ShaderMgr *sm)
 	  m_font(nullptr), m_pen(nullptr), m_brush(nullptr),
 	  m_textCol(0xFFFFFF), m_bgCol(0x000000),
 	  m_bkMode(BK_TRANSPARENT), m_tah(LEFT), m_tav(TOP),
-	  m_cx(0), m_cy(0), m_ox(0), m_oy(0)
+	  m_cx(0), m_cy(0), m_ox(0), m_oy(0),
+	  m_lineScale(1.0f), m_patternScale(1.0f),
+	  m_quickPen(nullptr), m_quickBrush(nullptr),
+	  m_colourCompat(true)
 {
 	if (m_surf) {
 		m_viewW = m_surf->GetWidth();
@@ -128,6 +135,8 @@ OGLSketchpad::OGLSketchpad(SURFHANDLE surf, ShaderMgr *sm)
 OGLSketchpad::~OGLSketchpad()
 {
 	UnbindState();
+	delete m_quickPen;
+	delete m_quickBrush;
 }
 
 void OGLSketchpad::BindState()
@@ -153,6 +162,12 @@ void OGLSketchpad::BindState()
 	glUniformMatrix4fv(s_locColorMat, 1, GL_FALSE, m_colorMat);
 	glUniform4fv(s_locGamma, 1, m_gamma);
 	glUniform4fv(s_locNoise, 1, m_noise);
+
+	// Colour-key + second colour default off / transparent — blit and
+	// gradient helpers will overwrite them as needed per-draw.
+	const float off[4] = { 0, 0, 0, 0 };
+	glUniform4fv(s_locColor2, 1, off);
+	glUniform4fv(s_locColorKey, 1, off);
 }
 
 void OGLSketchpad::UnbindState()
@@ -226,16 +241,17 @@ DWORD OGLSketchpad::GetTextWidth(const char *str, int len) {
 
 // --- Draw helpers ----------------------------------------------------------
 
-void OGLSketchpad::PackColor(DWORD col, float out[4])
+void OGLSketchpad::PackColor(DWORD col, float out[4]) const
 {
-	// Orbiter stores 0xBBGGRR. An alpha byte in bits 24-31 is optional
-	// (D3D9 flagging); zero alpha is treated as fully opaque — this matches
-	// the oapi::ColorCompatibility default every client ships with.
+	// Orbiter stores 0xBBGGRR. The alpha byte (bits 24-31) is optional;
+	// the ColorCompatibility default treats alpha==0 as "fully opaque"
+	// which is what every D3D9 caller historically assumed. Sketchpads
+	// that opt out (ColorCompatibility(false)) get the raw alpha byte.
 	float r = ((col >> 16) & 0xFF) / 255.0f;
 	float g = ((col >>  8) & 0xFF) / 255.0f;
 	float b = ( col        & 0xFF) / 255.0f;
 	float a = ((col >> 24) & 0xFF) / 255.0f;
-	if (a < 1.0f / 255.0f) a = 1.0f;
+	if (m_colourCompat && a < 1.0f / 255.0f) a = 1.0f;
 	out[0] = r; out[1] = g; out[2] = b; out[3] = a;
 }
 
@@ -654,6 +670,431 @@ oapi::FVECTOR4 OGLSketchpad::GetRenderParam(RenderParam param)
 		return oapi::FVECTOR4(m_noise[0], m_noise[1], m_noise[2], m_noise[3]);
 	}
 	return oapi::FVECTOR4(0, 0, 0, 0);
+}
+
+// --- Quick resources -------------------------------------------------------
+
+void OGLSketchpad::QuickPen(DWORD color, float width, DWORD style)
+{
+	delete m_quickPen;
+	m_quickPen = new OGLPen((int)style, (int)(width + 0.5f), color);
+	m_pen = m_quickPen;
+}
+
+void OGLSketchpad::QuickBrush(DWORD color)
+{
+	delete m_quickBrush;
+	m_quickBrush = new OGLBrush(color);
+	m_brush = m_quickBrush;
+}
+
+void OGLSketchpad::SetGlobalLineScale(float width, float pattern)
+{
+	m_lineScale    = width;
+	m_patternScale = pattern;
+}
+
+void OGLSketchpad::ColorCompatibility(bool bEnable)
+{
+	m_colourCompat = bEnable;
+}
+
+// --- State -----------------------------------------------------------------
+
+void OGLSketchpad::SetBlendState(BlendState state)
+{
+	// Low 4 bits pick the colour-combining rule, next nibble picks the
+	// texture sampling filter. The filter selection is handed to the
+	// OGLSurface sampler we bind in blits — for the immediate draw call
+	// we only need to set glBlendFunc for the colour combiner.
+	const int combiner = state & 0x0F;
+	glEnable(GL_BLEND);
+	switch (combiner) {
+	case COPY:
+		glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ONE, GL_ZERO);
+		break;
+	case COPY_ALPHA:
+		glBlendFuncSeparate(GL_ZERO, GL_ONE, GL_ONE, GL_ZERO);
+		break;
+	case COPY_COLOR:
+		glBlendFuncSeparate(GL_ONE, GL_ZERO, GL_ZERO, GL_ONE);
+		break;
+	case ALPHABLEND:
+	default:
+		glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA,
+		                    GL_ONE,       GL_ONE_MINUS_SRC_ALPHA);
+		break;
+	}
+}
+
+void OGLSketchpad::DepthEnable(bool bEnable)
+{
+	if (bEnable) glEnable(GL_DEPTH_TEST);
+	else         glDisable(GL_DEPTH_TEST);
+}
+
+void OGLSketchpad::Clear(DWORD color, bool bColor, bool bDepth)
+{
+	GLbitfield mask = 0;
+	if (bColor) {
+		float c[4]; PackColor(color, c);
+		glClearColor(c[0], c[1], c[2], c[3]);
+		mask |= GL_COLOR_BUFFER_BIT;
+	}
+	if (bDepth) {
+		glClearDepth(1.0);
+		mask |= GL_DEPTH_BUFFER_BIT;
+	}
+	if (mask) glClear(mask);
+}
+
+// --- Solid fills ----------------------------------------------------------
+
+void OGLSketchpad::ColorFill(DWORD color, const LPRECT tgt)
+{
+	if (!tgt) return;
+	float ax = (float)tgt->left, ay = (float)tgt->top;
+	float bx = (float)tgt->right, by = (float)tgt->bottom;
+	const float tri[6 * 2] = {
+		ax, ay, bx, ay, ax, by,
+		bx, ay, bx, by, ax, by,
+	};
+	DrawSolidTriangles(tri, 6, color);
+}
+
+void OGLSketchpad::GradientFillRect(const LPRECT tgt, DWORD c1, DWORD c2, bool bVertical)
+{
+	if (!tgt) return;
+	float ax = (float)tgt->left, ay = (float)tgt->top;
+	float bx = (float)tgt->right, by = (float)tgt->bottom;
+
+	// Pack pos + interpolation t into the UV channel so the existing
+	// pos/UV VBO layout can carry the gradient direction.
+	const float verts[6 * 4] = {
+		ax, ay, 0, 0,
+		bx, ay, 1, 0,
+		ax, by, 0, 1,
+		bx, ay, 1, 0,
+		bx, by, 1, 1,
+		ax, by, 0, 1,
+	};
+
+	float ca[4], cb[4];
+	PackColor(c1, ca); PackColor(c2, cb);
+	glBindBuffer(GL_ARRAY_BUFFER, s_vbo);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STREAM_DRAW);
+	glUniform4fv(s_locColor, 1, ca);
+	glUniform4fv(s_locColor2, 1, cb);
+	glUniform1i(s_locMode, bVertical ? 4 : 3);
+	glDrawArrays(GL_TRIANGLES, 0, 6);
+	// Restore default Color2 so subsequent solid fills don't see stale data.
+	const float off[4] = { 0, 0, 0, 0 };
+	glUniform4fv(s_locColor2, 1, off);
+}
+
+void OGLSketchpad::FillTetragon(DWORD color, const oapi::FVECTOR2 pt[4])
+{
+	if (!pt) return;
+	const float tri[6 * 2] = {
+		pt[0].x, pt[0].y, pt[1].x, pt[1].y, pt[2].x, pt[2].y,
+		pt[0].x, pt[0].y, pt[2].x, pt[2].y, pt[3].x, pt[3].y,
+	};
+	DrawSolidTriangles(tri, 6, color);
+}
+
+// --- Blit family ----------------------------------------------------------
+
+static inline void UvRect(OGLSurface *surf, const LPRECT src,
+                          float &u0, float &v0, float &u1, float &v1)
+{
+	const float sw = (float)surf->GetWidth();
+	const float sh = (float)surf->GetHeight();
+	if (src) {
+		u0 = src->left   / sw;
+		v0 = src->top    / sh;
+		u1 = src->right  / sw;
+		v1 = src->bottom / sh;
+	} else {
+		u0 = 0.0f; v0 = 0.0f; u1 = 1.0f; v1 = 1.0f;
+	}
+}
+
+void OGLSketchpad::CopyRect(const SURFHANDLE hSrc, const LPRECT src, int tx, int ty)
+{
+	if (!hSrc) return;
+	OGLSurface *srcS = (OGLSurface*)hSrc;
+
+	float u0, v0, u1, v1;
+	UvRect(srcS, src, u0, v0, u1, v1);
+	int w = src ? (src->right - src->left) : (int)srcS->GetWidth();
+	int h = src ? (src->bottom - src->top) : (int)srcS->GetHeight();
+	float ax = (float)tx, ay = (float)ty;
+	float bx = ax + (float)w, by = ay + (float)h;
+
+	const float verts[6 * 4] = {
+		ax, ay, u0, v0,
+		bx, ay, u1, v0,
+		ax, by, u0, v1,
+		bx, ay, u1, v0,
+		bx, by, u1, v1,
+		ax, by, u0, v1,
+	};
+	const float white = 1.0f;
+	const float col[4] = { white, white, white, white };
+	DrawTexturedQuads(verts, 6, srcS->GetTexture(), 0xFFFFFFFF, MODE_TEXTURE);
+	(void)col;
+}
+
+void OGLSketchpad::StretchRect(const SURFHANDLE hSrc, const LPRECT src, const LPRECT tgt)
+{
+	if (!hSrc) return;
+	OGLSurface *srcS = (OGLSurface*)hSrc;
+
+	float u0, v0, u1, v1;
+	UvRect(srcS, src, u0, v0, u1, v1);
+	float ax, ay, bx, by;
+	if (tgt) {
+		ax = (float)tgt->left;  ay = (float)tgt->top;
+		bx = (float)tgt->right; by = (float)tgt->bottom;
+	} else {
+		ax = 0.0f; ay = 0.0f;
+		bx = (float)m_viewW; by = (float)m_viewH;
+	}
+
+	const float verts[6 * 4] = {
+		ax, ay, u0, v0,
+		bx, ay, u1, v0,
+		ax, by, u0, v1,
+		bx, ay, u1, v0,
+		bx, by, u1, v1,
+		ax, by, u0, v1,
+	};
+	DrawTexturedQuads(verts, 6, srcS->GetTexture(), 0xFFFFFFFF, MODE_TEXTURE);
+}
+
+void OGLSketchpad::RotateRect(const SURFHANDLE hSrc, const LPRECT src,
+                              int cx, int cy, float angle, float sw, float sh)
+{
+	if (!hSrc) return;
+	OGLSurface *srcS = (OGLSurface*)hSrc;
+
+	float u0, v0, u1, v1;
+	UvRect(srcS, src, u0, v0, u1, v1);
+	int rw = src ? (src->right - src->left) : (int)srcS->GetWidth();
+	int rh = src ? (src->bottom - src->top) : (int)srcS->GetHeight();
+	float hx = 0.5f * rw * sw;
+	float hy = 0.5f * rh * sh;
+
+	// Corners around the local origin, rotated by `angle` radians,
+	// then translated to (cx, cy).
+	const float c = std::cos(angle), s = std::sin(angle);
+	auto rot = [&](float lx, float ly, float &ox, float &oy) {
+		ox = cx + c * lx - s * ly;
+		oy = cy + s * lx + c * ly;
+	};
+	float x0, y0, x1, y1, x2, y2, x3, y3;
+	rot(-hx, -hy, x0, y0);
+	rot( hx, -hy, x1, y1);
+	rot( hx,  hy, x2, y2);
+	rot(-hx,  hy, x3, y3);
+
+	const float verts[6 * 4] = {
+		x0, y0, u0, v0,
+		x1, y1, u1, v0,
+		x3, y3, u0, v1,
+		x1, y1, u1, v0,
+		x2, y2, u1, v1,
+		x3, y3, u0, v1,
+	};
+	DrawTexturedQuads(verts, 6, srcS->GetTexture(), 0xFFFFFFFF, MODE_TEXTURE);
+}
+
+void OGLSketchpad::ColorKey(const SURFHANDLE hSrc, const LPRECT src, int tx, int ty)
+{
+	if (!hSrc) return;
+	OGLSurface *srcS = (OGLSurface*)hSrc;
+	if (!srcS->HasColorKey()) { CopyRect(hSrc, src, tx, ty); return; }
+
+	// Activate the chroma-key discard branch by setting uColorKey.a = 1
+	// with the source surface's key colour.
+	DWORD key = srcS->GetColorKey();
+	float k[4] = {
+		((key >> 16) & 0xFF) / 255.0f,
+		((key >>  8) & 0xFF) / 255.0f,
+		( key        & 0xFF) / 255.0f,
+		1.0f
+	};
+	glUniform4fv(s_locColorKey, 1, k);
+
+	CopyRect(hSrc, src, tx, ty);
+
+	// Restore default so the next unrelated draw doesn't discard.
+	const float off[4] = { 0, 0, 0, 0 };
+	glUniform4fv(s_locColorKey, 1, off);
+}
+
+void OGLSketchpad::CopyTetragon(const SURFHANDLE hSrc, const LPRECT sr,
+                                const oapi::FVECTOR2 pt[4])
+{
+	if (!hSrc || !pt) return;
+	OGLSurface *srcS = (OGLSurface*)hSrc;
+
+	float u0, v0, u1, v1;
+	UvRect(srcS, sr, u0, v0, u1, v1);
+
+	const float verts[6 * 4] = {
+		pt[0].x, pt[0].y, u0, v0,
+		pt[1].x, pt[1].y, u1, v0,
+		pt[3].x, pt[3].y, u0, v1,
+		pt[1].x, pt[1].y, u1, v0,
+		pt[2].x, pt[2].y, u1, v1,
+		pt[3].x, pt[3].y, u0, v1,
+	};
+	DrawTexturedQuads(verts, 6, srcS->GetTexture(), 0xFFFFFFFF, MODE_TEXTURE);
+}
+
+// Nine-slice stretch. `rgn->intr` is the inner (fixed-extent) rect in
+// source space; `rgn->outr` is the outer source rect. `out` is the target
+// rect: corners keep their source size, edges stretch along one axis,
+// centre stretches on both. Nine separate blits — the overhead is
+// negligible since 9-slice is almost exclusively used by UI plugins at
+// low call frequency.
+void OGLSketchpad::StretchRegion(const skpRegion *rgn, const SURFHANDLE hSrc,
+                                 const LPRECT out)
+{
+	if (!rgn || !hSrc || !out) return;
+
+	const LONG sl = rgn->outr.left,  st = rgn->outr.top;
+	const LONG sr = rgn->outr.right, sb = rgn->outr.bottom;
+	const LONG il = rgn->intr.left,  it = rgn->intr.top;
+	const LONG ir = rgn->intr.right, ib = rgn->intr.bottom;
+
+	const LONG tl = out->left,  tt = out->top;
+	const LONG tr = out->right, tb = out->bottom;
+	const LONG tiL = tl + (il - sl);      // inner target rect, derived
+	const LONG tiT = tt + (it - st);
+	const LONG tiR = tr - (sr - ir);
+	const LONG tiB = tb - (sb - ib);
+
+	auto stretch = [&](LONG sx0, LONG sy0, LONG sx1, LONG sy1,
+	                   LONG tx0, LONG ty0, LONG tx1, LONG ty1) {
+		RECT s = { sx0, sy0, sx1, sy1 };
+		RECT t = { tx0, ty0, tx1, ty1 };
+		StretchRect(hSrc, &s, &t);
+	};
+
+	// corners
+	stretch(sl, st, il, it, tl,  tt,  tiL, tiT);
+	stretch(ir, st, sr, it, tiR, tt,  tr,  tiT);
+	stretch(sl, ib, il, sb, tl,  tiB, tiL, tb);
+	stretch(ir, ib, sr, sb, tiR, tiB, tr,  tb);
+	// edges
+	stretch(il, st, ir, it, tiL, tt,  tiR, tiT);
+	stretch(il, ib, ir, sb, tiL, tiB, tiR, tb);
+	stretch(sl, it, il, ib, tl,  tiT, tiL, tiB);
+	stretch(ir, it, sr, ib, tiR, tiT, tr,  tiB);
+	// centre
+	stretch(il, it, ir, ib, tiL, tiT, tiR, tiB);
+}
+
+// --- Misc primitives -------------------------------------------------------
+
+void OGLSketchpad::Lines(const oapi::FVECTOR2 *pt1, int nlines)
+{
+	if (!pt1 || nlines <= 0 || !m_pen || m_pen->style == 0) return;
+	const int nVerts = nlines * 2;
+	std::vector<float> xy(nVerts * 2);
+	for (int i = 0; i < nVerts; i++) {
+		xy[i * 2 + 0] = pt1[i].x + (float)m_ox;
+		xy[i * 2 + 1] = pt1[i].y + (float)m_oy;
+	}
+	DrawSolidLines(xy.data(), nVerts, m_pen->col,
+	               (int)std::max(1.0f, m_pen->width * m_lineScale));
+}
+
+bool OGLSketchpad::TextW(int x, int y, const LPWSTR str, int len)
+{
+	if (!str) return false;
+	// Convert UTF-16/UCS-2 (LPWSTR on the oapi side is uint16_t*) to UTF-8
+	// and fall through to Text(). This keeps glyph lookup in one place
+	// while still honouring locale-specific wide strings from Lua scripts.
+	const uint16_t *w = (const uint16_t*)str;
+	int n = 0;
+	if (len > 0) n = len;
+	else while (w[n]) n++;
+
+	std::string utf8;
+	utf8.reserve(n * 3);
+	for (int i = 0; i < n; i++) {
+		uint32_t cp = w[i];
+		if (cp < 0x80) {
+			utf8.push_back((char)cp);
+		} else if (cp < 0x800) {
+			utf8.push_back((char)(0xC0 | (cp >> 6)));
+			utf8.push_back((char)(0x80 | (cp & 0x3F)));
+		} else {
+			utf8.push_back((char)(0xE0 | (cp >> 12)));
+			utf8.push_back((char)(0x80 | ((cp >> 6) & 0x3F)));
+			utf8.push_back((char)(0x80 | (cp & 0x3F)));
+		}
+	}
+	return Text(x, y, utf8.c_str(), (int)utf8.size());
+}
+
+void OGLSketchpad::TextEx(float x, float y, const char *str,
+                          float scale, float angle)
+{
+	if (!str || !*str) return;
+	// Scale and rotation operate around the text anchor (x, y). Per-glyph
+	// quads are rotated individually so letter spacing follows the angle.
+	ImFont *imf = m_font ? m_font->imFont : ImGui::GetFont();
+	float sz = (m_font ? m_font->fontSize : 14.0f) * scale;
+	if (!imf) return;
+	ImFontBaked *baked = imf->GetFontBaked(sz);
+	ImFontAtlas *atlas = ImGui::GetIO().Fonts;
+	GLuint atlasTex = atlas ? (GLuint)(std::uintptr_t)atlas->TexRef.GetTexID() : 0;
+	if (!baked || !atlasTex) return;
+
+	const float c = std::cos(angle), s = std::sin(angle);
+	const float ax = x + (float)m_ox, ay = y + (float)m_oy;
+
+	float pen = 0.0f;  // distance along the (rotated) baseline
+	std::vector<float> quads;
+	const char *end = str + std::strlen(str);
+	for (const char *p = str; p < end; ) {
+		unsigned int cp = 0;
+		int bytes = ImTextCharFromUtf8(&cp, p, end);
+		if (bytes <= 0) break;
+		p += bytes;
+		ImFontGlyph *g = baked->FindGlyph((ImWchar)cp);
+		if (!g) continue;
+
+		// Local-space (unrotated) corners.
+		const float lx0 = pen + g->X0, lx1 = pen + g->X1;
+		const float ly0 = g->Y0,       ly1 = g->Y1;
+		auto rot = [&](float lx, float ly, float &ox, float &oy) {
+			ox = ax + c * lx - s * ly;
+			oy = ay + s * lx + c * ly;
+		};
+		float rx0, ry0, rx1, ry1, rx2, ry2, rx3, ry3;
+		rot(lx0, ly0, rx0, ry0);
+		rot(lx1, ly0, rx1, ry1);
+		rot(lx1, ly1, rx2, ry2);
+		rot(lx0, ly1, rx3, ry3);
+
+		quads.insert(quads.end(), {
+			rx0, ry0, g->U0, g->V0,
+			rx1, ry1, g->U1, g->V0,
+			rx3, ry3, g->U0, g->V1,
+			rx1, ry1, g->U1, g->V0,
+			rx2, ry2, g->U1, g->V1,
+			rx3, ry3, g->U0, g->V1,
+		});
+		pen += g->AdvanceX;
+	}
+	if (!quads.empty())
+		DrawTexturedQuads(quads.data(), (int)(quads.size() / 4),
+		                  atlasTex, m_textCol, MODE_TEXT);
 }
 
 } // namespace ogl

--- a/OVP/OGLClient/OGLSketchpad.h
+++ b/OVP/OGLClient/OGLSketchpad.h
@@ -97,6 +97,43 @@ public:
 	                         const oapi::FVECTOR4 *data = nullptr) override;
 	oapi::FVECTOR4 GetRenderParam(RenderParam param) override;
 
+	// -- Quick resource + pen/brush helpers --
+	void QuickPen(DWORD color, float width = 1.0f, DWORD style = 1) override;
+	void QuickBrush(DWORD color) override;
+	void SetGlobalLineScale(float width = 1.0f, float pattern = 1.0f) override;
+	void ColorCompatibility(bool bEnable) override;
+
+	// -- State --
+	void SetBlendState(BlendState state = (BlendState)(BlendState::ALPHABLEND |
+	                                                   BlendState::FILTER_LINEAR)) override;
+	void DepthEnable(bool enable) override;
+	void Clear(DWORD color = 0, bool bColor = true, bool bDepth = true) override;
+
+	// -- Fills --
+	void ColorFill(DWORD color, const LPRECT tgt) override;
+	void GradientFillRect(const LPRECT tgt, DWORD c1, DWORD c2,
+	                      bool bVertical = false) override;
+	void FillTetragon(DWORD color, const oapi::FVECTOR2 pt[4]) override;
+
+	// -- Blits --
+	void CopyRect(const SURFHANDLE hSrc, const LPRECT src, int tx, int ty) override;
+	void StretchRect(const SURFHANDLE hSrc, const LPRECT src = nullptr,
+	                 const LPRECT tgt = nullptr) override;
+	void RotateRect(const SURFHANDLE hSrc, const LPRECT src,
+	                int cx, int cy, float angle = 0.0f,
+	                float sw = 1.0f, float sh = 1.0f) override;
+	void ColorKey(const SURFHANDLE hSrc, const LPRECT src, int tx, int ty) override;
+	void CopyTetragon(const SURFHANDLE hSrc, const LPRECT sr,
+	                  const oapi::FVECTOR2 pt[4]) override;
+	void StretchRegion(const skpRegion *rgn, const SURFHANDLE hSrc,
+	                   const LPRECT out) override;
+
+	// -- Misc primitives --
+	void Lines(const oapi::FVECTOR2 *pt1, int nlines) override;
+	bool TextW(int x, int y, const LPWSTR str, int len) override;
+	void TextEx(float x, float y, const char *str,
+	            float scale = 1.0f, float angle = 0.0f) override;
+
 	// -- Shared GL resource lifecycle --
 	static void InitShared(ShaderMgr *sm);
 	static void ReleaseShared();
@@ -117,8 +154,10 @@ private:
 	void DrawTexturedQuads(const float *xyuv, int nVerts,
 	                       GLuint tex, DWORD col, Mode mode);
 
-	// Packs Orbiter's 0xBBGGRR (+ optional alpha) into a vec4 for the shader.
-	static void PackColor(DWORD col, float out[4]);
+	// Packs Orbiter's 0xBBGGRR (+ optional alpha) into a vec4 for the
+	// shader. Honours m_colourCompat — when true (default) alpha==0 is
+	// rewritten to 0xFF, matching historical D3D9 semantics.
+	void PackColor(DWORD col, float out[4]) const;
 
 	// Target surface state.
 	OGLSurface *m_surf;
@@ -154,6 +193,8 @@ private:
 	static GLint  s_locColorMat;
 	static GLint  s_locGamma;
 	static GLint  s_locNoise;
+	static GLint  s_locColor2;
+	static GLint  s_locColorKey;
 	static bool   s_sharedInitialized;
 
 	// Colour-transform state. Defaults are identity so a Sketchpad that
@@ -166,6 +207,22 @@ private:
 	// Shadow of the last SetColorMatrix call so GetColorMatrix() can
 	// return a pointer with the same lifetime as the Sketchpad.
 	oapi::FMATRIX4 m_colorMatShadow;
+
+	// SetGlobalLineScale multipliers — applied to m_pen->width (and, in
+	// the future, to dashed pattern repeats) when stroking primitives.
+	float m_lineScale;
+	float m_patternScale;
+
+	// Transient Pen/Brush owned by QuickPen / QuickBrush — the public
+	// API lets callers skip the create-set-release dance. Destroyed
+	// when the Sketchpad is released.
+	OGLPen   *m_quickPen;
+	OGLBrush *m_quickBrush;
+
+	// Colour compatibility toggle (ColorCompatibility). When true the
+	// alpha=0 byte of every input colour is rewritten to 255 — matches
+	// the legacy D3D9 "alpha 0 means opaque" default.
+	bool m_colourCompat;
 };
 
 } // namespace ogl

--- a/OVP/OGLClient/OGLSketchpad.h
+++ b/OVP/OGLClient/OGLSketchpad.h
@@ -1,0 +1,151 @@
+// Copyright (c) Martin Schweiger
+// Licensed under the MIT License
+
+// OGLSketchpad — oapi::Sketchpad implementation for the OpenGL client.
+//
+// Renders every primitive directly into the bound SURFHANDLE's FBO via a
+// dedicated 2D shader (shaders/sketchpad.*); the previous implementation
+// drew through ImGui::GetForegroundDrawList() and so never touched the
+// target surface, leaving MFD textures black.
+//
+// Text is drawn by emitting per-glyph textured quads that sample ImGui's
+// font atlas (already uploaded to GL as part of ImGui_ImplOpenGL3 init).
+
+#ifndef __OGLSKETCHPAD_H
+#define __OGLSKETCHPAD_H
+
+#ifndef _WIN32
+
+#include "DrawAPI.h"
+#include "OrbiterAPI.h"
+#include <OpenGL/gl3.h>
+
+struct ImFont;
+
+namespace ogl {
+
+class ShaderMgr;
+class OGLSurface;
+
+// --- Font / Pen / Brush wrappers ------------------------------------------
+
+class OGLFont : public oapi::Font {
+public:
+	OGLFont(int height, bool prop, const char *face,
+	        FontStyle style, int orientation);
+	ImFont *imFont;
+	float   fontSize;
+};
+
+class OGLPen : public oapi::Pen {
+public:
+	OGLPen(int style, int width, DWORD col);
+	int   style;     // 0=none, 1=solid, 2=dashed
+	int   width;     // pixel width, min 1
+	DWORD col;       // 0xBBGGRR (Orbiter convention)
+};
+
+class OGLBrush : public oapi::Brush {
+public:
+	OGLBrush(DWORD col);
+	DWORD col;
+};
+
+// --- Sketchpad -------------------------------------------------------------
+
+class OGLSketchpad : public oapi::Sketchpad {
+public:
+	OGLSketchpad(SURFHANDLE surf, ShaderMgr *sm);
+	~OGLSketchpad();
+
+	// -- Font / Pen / Brush state --
+	oapi::Font *SetFont(oapi::Font *font) override;
+	oapi::Pen *SetPen(oapi::Pen *pen) override;
+	oapi::Brush *SetBrush(oapi::Brush *brush) override;
+
+	// -- Text state --
+	void SetTextAlign(TAlign_horizontal tah = LEFT,
+	                  TAlign_vertical   tav = TOP) override;
+	DWORD SetTextColor(DWORD col) override;
+	DWORD SetBackgroundColor(DWORD col) override;
+	void  SetBackgroundMode(BkgMode mode) override;
+
+	// -- Origin --
+	void SetOrigin(int x, int y) override;
+	void GetOrigin(int *x, int *y) const override;
+
+	// -- Metrics --
+	DWORD GetCharSize() override;
+	DWORD GetTextWidth(const char *str, int len = 0) override;
+
+	// -- Primitives --
+	bool Text(int x, int y, const char *str, int len) override;
+	void MoveTo(int x, int y) override;
+	void LineTo(int x, int y) override;
+	void Line(int x0, int y0, int x1, int y1) override;
+	void Rectangle(int x0, int y0, int x1, int y1) override;
+	void Ellipse(int x0, int y0, int x1, int y1) override;
+	void Polygon(const oapi::IVECTOR2 *pt, int npt) override;
+	void Polyline(const oapi::IVECTOR2 *pt, int npt) override;
+	void Pixel(int x, int y, DWORD col) override;
+
+	// -- Shared GL resource lifecycle --
+	static void InitShared(ShaderMgr *sm);
+	static void ReleaseShared();
+
+private:
+	// Render-mode constants for the shared fragment shader.
+	enum Mode : int { MODE_SOLID = 0, MODE_TEXTURE = 1, MODE_TEXT = 2 };
+
+	void BindState();
+	void UnbindState();
+
+	// Low-level draw helpers. All coordinates are already in target-pixel
+	// space (no origin offset applied here — the public methods fold it in).
+	void DrawSolidTriangles(const float *xy, int nVerts, DWORD col);
+	void DrawSolidLines(const float *xy, int nVerts, DWORD col, int width);
+	void DrawStrokedPolyline(const float *xy, int nVerts, DWORD col,
+	                         int width, bool closed);
+	void DrawTexturedQuads(const float *xyuv, int nVerts,
+	                       GLuint tex, DWORD col, Mode mode);
+
+	// Packs Orbiter's 0xBBGGRR (+ optional alpha) into a vec4 for the shader.
+	static void PackColor(DWORD col, float out[4]);
+
+	// Target surface state.
+	OGLSurface *m_surf;
+	ShaderMgr  *m_sm;
+	DWORD       m_viewW, m_viewH;
+
+	// Selected resources.
+	OGLFont  *m_font;
+	OGLPen   *m_pen;
+	OGLBrush *m_brush;
+
+	// Text state.
+	DWORD              m_textCol;
+	DWORD              m_bgCol;
+	BkgMode            m_bkMode;
+	TAlign_horizontal  m_tah;
+	TAlign_vertical    m_tav;
+
+	// Movable current point + origin offset.
+	int m_cx, m_cy;
+	int m_ox, m_oy;
+
+	// Shared program + VAO/VBO pool (one VAO is enough — all draws stream
+	// into the same dynamic VBO).
+	static GLuint s_program;
+	static GLuint s_vao;
+	static GLuint s_vbo;
+	static GLint  s_locViewport;
+	static GLint  s_locColor;
+	static GLint  s_locMode;
+	static GLint  s_locTexture;
+	static bool   s_sharedInitialized;
+};
+
+} // namespace ogl
+
+#endif // !_WIN32
+#endif // __OGLSKETCHPAD_H

--- a/OVP/OGLClient/OGLSketchpad.h
+++ b/OVP/OGLClient/OGLSketchpad.h
@@ -89,6 +89,14 @@ public:
 	void Polyline(const oapi::IVECTOR2 *pt, int npt) override;
 	void Pixel(int x, int y, DWORD col) override;
 
+	// -- Colour transforms --
+	void      SetBrightness(const oapi::FVECTOR4 *pBrightness = nullptr) override;
+	void      SetColorMatrix(const oapi::FMATRIX4 *pMatrix = nullptr) override;
+	const oapi::FMATRIX4 *GetColorMatrix() override;
+	void      SetRenderParam(RenderParam param,
+	                         const oapi::FVECTOR4 *data = nullptr) override;
+	oapi::FVECTOR4 GetRenderParam(RenderParam param) override;
+
 	// -- Shared GL resource lifecycle --
 	static void InitShared(ShaderMgr *sm);
 	static void ReleaseShared();
@@ -142,7 +150,22 @@ private:
 	static GLint  s_locColor;
 	static GLint  s_locMode;
 	static GLint  s_locTexture;
+	static GLint  s_locBrightness;
+	static GLint  s_locColorMat;
+	static GLint  s_locGamma;
+	static GLint  s_locNoise;
 	static bool   s_sharedInitialized;
+
+	// Colour-transform state. Defaults are identity so a Sketchpad that
+	// never calls Set* paints the same as before M17.b.
+	float m_brightness[4];  // multiplicative rgba
+	float m_colorMat[16];   // row-major 4x4
+	float m_gamma[4];       // rgb = 1/gamma exponent
+	float m_noise[4];       // rgb tint, a blend (0 = off)
+
+	// Shadow of the last SetColorMatrix call so GetColorMatrix() can
+	// return a pointer with the same lifetime as the Sketchpad.
+	oapi::FMATRIX4 m_colorMatShadow;
 };
 
 } // namespace ogl

--- a/OVP/OGLClient/OGLSketchpad.h
+++ b/OVP/OGLClient/OGLSketchpad.h
@@ -19,6 +19,8 @@
 #include "DrawAPI.h"
 #include "OrbiterAPI.h"
 #include <OpenGL/gl3.h>
+#include <array>
+#include <vector>
 
 struct ImFont;
 
@@ -134,6 +136,39 @@ public:
 	void TextEx(float x, float y, const char *str,
 	            float scale = 1.0f, float angle = 0.0f) override;
 
+	// -- Transform state --
+	void SetWorldTransform(const oapi::FMATRIX4 *pWT = nullptr) override;
+	void SetWorldTransform2D(float scale = 1.0f, float rot = 0.0f,
+	                         const oapi::IVECTOR2 *ctr = nullptr,
+	                         const oapi::IVECTOR2 *trl = nullptr) override;
+	oapi::FMATRIX4 GetWorldTransform() const override;
+	void PushWorldTransform() override;
+	void PopWorldTransform() override;
+
+	// -- View / projection --
+	void SetViewMatrix(const oapi::FMATRIX4 *pV = nullptr) override;
+	void SetProjectionMatrix(const oapi::FMATRIX4 *pP = nullptr) override;
+	const oapi::FMATRIX4 *ViewMatrix() const override;
+	const oapi::FMATRIX4 *ProjectionMatrix() const override;
+	const oapi::FMATRIX4 *GetViewProjectionMatrix() const override;
+	void SetViewMode(SkpView mode = ORTHO) override;
+
+	// -- Clipping / surface metrics --
+	void ClipRect(const LPRECT pClip = nullptr) override;
+	void Clipper(int idx, const VECTOR3 *pPos = nullptr,
+	             double cos_angle = 0.0, double dist = 0.0) override;
+	void SetClipDistance(float _near, float _far) override;
+	void GetRenderSurfaceSize(LPSIZE size) override;
+
+	// -- Mesh + world-facing primitives --
+	int  DrawMeshGroup(const MESHHANDLE hMesh, DWORD grp,
+	                   MeshFlags flags = MeshFlags::SMOOTH_SHADE,
+	                   const SURFHANDLE hTex = nullptr) override;
+	void DrawPoly(const HPOLY hPoly, DWORD flags = 0) override;
+	void SetWorldBillboard(const oapi::FVECTOR3 &wpos, float scl = 1.0f,
+	                       bool bFixed = true,
+	                       const oapi::FVECTOR3 *index = nullptr) override;
+
 	// -- Shared GL resource lifecycle --
 	static void InitShared(ShaderMgr *sm);
 	static void ReleaseShared();
@@ -195,6 +230,11 @@ private:
 	static GLint  s_locNoise;
 	static GLint  s_locColor2;
 	static GLint  s_locColorKey;
+	static GLint  s_locWorld;
+	static GLint  s_locViewProj;
+	static GLint  s_locViewMode;
+	static GLint  s_locClipperDir;
+	static GLint  s_locClipperCosDist;
 	static bool   s_sharedInitialized;
 
 	// Colour-transform state. Defaults are identity so a Sketchpad that
@@ -223,6 +263,30 @@ private:
 	// alpha=0 byte of every input colour is rewritten to 255 — matches
 	// the legacy D3D9 "alpha 0 means opaque" default.
 	bool m_colourCompat;
+
+	// Transform + view/projection state. Identity by default so ORTHO
+	// pixel-space mode reproduces pre-M17.d behaviour exactly.
+	float m_world[16];
+	float m_view[16];
+	float m_proj[16];
+	float m_viewProj[16];    // view * proj, recomputed on any Set*Matrix
+	int   m_viewMode;        // ORTHO = 0, USER = 1
+
+	// Shadow pointers for ViewMatrix()/ProjectionMatrix() getters whose
+	// lifetime must outlive a single call.
+	oapi::FMATRIX4 m_viewShadow, m_projShadow, m_viewProjShadow;
+
+	// World-transform stack for PushWorldTransform/PopWorldTransform.
+	// Small reserved capacity covers the usual one-two deep usage.
+	std::vector<std::array<float, 16>> m_worldStack;
+
+	// Two Clipper slots (world-space cone).
+	float m_clipperDir[2][4];          // xyz = unit direction, w = enable
+	float m_clipperCosDist[2][2];      // x = cos(angle), y = near-distance
+
+	// Near/far clip planes for SetClipDistance. Only meaningful in USER
+	// view mode — default values match the D3D9 defaults.
+	float m_clipNear, m_clipFar;
 };
 
 } // namespace ogl

--- a/OVP/OGLClient/OGLvVessel.cpp
+++ b/OVP/OGLClient/OGLvVessel.cpp
@@ -37,6 +37,30 @@ static bool FileExists(const char *path) {
 	return stat(path, &st) == 0;
 }
 
+// Port of D3D9Client vVessel::Render mesh-visibility filter (VVessel.cpp:739-757).
+// Returns true when the mesh should be drawn in the current pass.
+// `internalpass` distinguishes the external/VC pass; `bCockpit` is true when the
+// focus vessel is in internal view; `bVC` when cockpit mode is COCKPIT_VIRTUAL.
+static bool ShouldRenderMesh(WORD vismode, bool internalpass, bool bCockpit, bool bVC)
+{
+	if (vismode == 0) return false;                           // MESHVIS_NEVER
+
+	if (!internalpass) {
+		if (vismode == MESHVIS_VC) return false;              // pure-VC mesh never external
+		if (!(vismode & MESHVIS_EXTPASS) && bCockpit) return false;
+	}
+
+	if (bCockpit) {
+		if (internalpass && (vismode & MESHVIS_EXTPASS)) return false;
+		if (!(vismode & MESHVIS_COCKPIT)) {
+			if (!bVC || !(vismode & MESHVIS_VC)) return false;
+		}
+	} else {
+		if (!(vismode & MESHVIS_EXTERNAL)) return false;
+	}
+	return true;
+}
+
 CachedMesh::~CachedMesh() {
 	for (auto &g : groups) {
 		if (g.vao)    glDeleteVertexArrays(1, &g.vao);
@@ -278,6 +302,14 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 	GLuint activeShader = s_pbrShader ? s_pbrShader : s_vesselShader;
 	const bool pbrActive = (activeShader == s_pbrShader);
 
+	// Cockpit-view state: F1 toggles camera internal/external; when internal
+	// and this vessel is the focus we run a second pass with internalpass=true
+	// so MESHVIS_VC/MESHVIS_COCKPIT meshes can draw. Planetarium/env/shadow
+	// cameras never enter this path because they're not the "main" view.
+	const bool bCockpit = (oapiCameraInternal() && (m_hObj == oapiGetFocusObject()));
+	const bool bVC      = (bCockpit && (oapiCockpitMode() == COCKPIT_VIRTUAL));
+	const int  nPasses  = bCockpit ? 2 : 1;
+
 	// ----- Shadow pre-pass (PBR path only) ----------------------------------
 	// Render the vessel's meshes into the shared shadow depth map from the
 	// sun's point of view. Both passes work in the distance-normalised frame
@@ -298,6 +330,13 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 
 		DWORD nMeshShadow = vessel->GetMeshCount();
 		for (DWORD m = 0; m < nMeshShadow; m++) {
+			// Sun's POV is always external — filter out VC/cockpit-only meshes
+			// so we don't pay shadow cost for geometry that's never lit (and
+			// avoid self-shadowing artefacts from interior panels).
+			WORD vismode = vessel->GetMeshVisibilityMode(m);
+			if (!ShouldRenderMesh(vismode, /*internalpass=*/false, /*bCockpit=*/false, /*bVC=*/false))
+				continue;
+
 			MESHHANDLE hMesh = vessel->GetMeshTemplate(m);
 			if (!hMesh) {
 				const char *className = vessel->GetClassName();
@@ -371,7 +410,18 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 	}
 
 	DWORD nMesh = vessel->GetMeshCount();
+	// Pass 0: external (hull, EXTPASS bits even while in cockpit view).
+	// Pass 1: internal/VC — only runs when the focus vessel is in internal
+	// view. Both passes share the same shader state; depth buffer is kept
+	// across passes so any EXTPASS geometry (hull seen through windows)
+	// occludes VC interior correctly through the usual z-test.
+	for (int pass = 0; pass < nPasses; pass++) {
+		const bool internalpass = (pass == 1);
+
 	for (DWORD m = 0; m < nMesh; m++) {
+		WORD vismode = vessel->GetMeshVisibilityMode(m);
+		if (!ShouldRenderMesh(vismode, internalpass, bCockpit, bVC)) continue;
+
 		MESHHANDLE hMesh = vessel->GetMeshTemplate(m);
 		if (!hMesh) {
 			const char *className = vessel->GetClassName();
@@ -455,6 +505,7 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 			glDrawElements(GL_TRIANGLES, cmg.indexCount, GL_UNSIGNED_INT, 0);
 		}
 	}
+	} // end pass loop
 	glBindVertexArray(0);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glUseProgram(0);

--- a/OVP/OGLClient/OGLvVessel.cpp
+++ b/OVP/OGLClient/OGLvVessel.cpp
@@ -333,6 +333,24 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 		}
 	}
 
+	// Cache the VC HUD binding. Unlike MFDs the HUD is an additive overlay:
+	// the group draws once with its base texture (window glass), then we
+	// re-draw the same geometry with the HUD surface and an additive blend
+	// so the transparent sketchpad background leaves the glass visible and
+	// only the painted strokes add colour — equivalent to the 0x100 screen
+	// type D3D9Client tags its HUD group with (VVessel.cpp:802-806).
+	DWORD hudMesh = (DWORD)-1, hudGroup = (DWORD)-1;
+	OGLSurface *hudSurf = nullptr;
+	if (bVC && s_gc) {
+		const VCHUDSPEC *hudspec = nullptr;
+		SURFHANDLE s = s_gc->GetVCHUDSurface(&hudspec);
+		if (s && hudspec) {
+			hudMesh  = hudspec->nmesh;
+			hudGroup = hudspec->ngroup;
+			hudSurf  = (OGLSurface*)s;
+		}
+	}
+
 	// ----- Shadow pre-pass (PBR path only) ----------------------------------
 	// Render the vessel's meshes into the shared shadow depth map from the
 	// sun's point of view. Both passes work in the distance-normalised frame
@@ -545,6 +563,36 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 
 			glBindVertexArray(cmg.vao);
 			glDrawElements(GL_TRIANGLES, cmg.indexCount, GL_UNSIGNED_INT, 0);
+
+			// VC HUD overlay: re-draw the matching group additively with the
+			// HUD surface on top. The sketchpad background is transparent so
+			// only stroked pixels contribute; the underlying window glass
+			// (just drawn above) stays visible.
+			if (internalpass && bVC && hudSurf && m == hudMesh && g == hudGroup) {
+				GLuint hudTexId = hudSurf->GetTexture();
+				if (hudTexId) {
+					glActiveTexture(GL_TEXTURE0);
+					glBindTexture(GL_TEXTURE_2D, hudTexId);
+					GLint texLoc = s_shaderMgr->GetUniformLoc(activeShader,
+						activeShader == s_pbrShader ? "uDiffuseTex" : "uTexture");
+					glUniform1i(texLoc, 0);
+
+					// Emissive-only material so the HUD strokes aren't
+					// modulated by diffuse lighting — HUD should read the
+					// same at any cockpit orientation.
+					UBOMaterialData hudMat = matData;
+					hudMat.hasDiffuse = 1;
+					hudMat.hasEnvMap  = 0;
+					s_shaderMgr->UpdateUBO(s_materialUBO, sizeof(hudMat), &hudMat);
+
+					glEnable(GL_BLEND);
+					glBlendFunc(GL_SRC_ALPHA, GL_ONE);  // additive, alpha-weighted
+					glDepthMask(GL_FALSE);
+					glDrawElements(GL_TRIANGLES, cmg.indexCount, GL_UNSIGNED_INT, 0);
+					glDepthMask(GL_TRUE);
+					glDisable(GL_BLEND);
+				}
+			}
 		}
 	}
 	} // end pass loop

--- a/OVP/OGLClient/OGLvVessel.cpp
+++ b/OVP/OGLClient/OGLvVessel.cpp
@@ -12,6 +12,7 @@
 #include "OGLTexture.h"
 #include "OGLSurface.h"
 #include "VesselAPI.h"
+#include "GraphicsAPI.h"
 #include <cstdio>
 #include <cmath>
 #include <sys/stat.h>
@@ -30,6 +31,7 @@ OGLTexture *OGLvVessel::s_exhaustTexture = nullptr;
 bool OGLvVessel::s_sharedInitialized = false;
 ShaderMgr *OGLvVessel::s_shaderMgr = nullptr;
 OGLEnvMap *OGLvVessel::s_envMap = nullptr;
+oapi::GraphicsClient *OGLvVessel::s_gc = nullptr;
 std::map<std::string, MESHHANDLE> OGLvVessel::s_fallbackMeshes;
 
 static bool FileExists(const char *path) {
@@ -310,6 +312,27 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 	const bool bVC      = (bCockpit && (oapiCockpitMode() == COCKPIT_VIRTUAL));
 	const int  nPasses  = bCockpit ? 2 : 1;
 
+	// Cache VC MFD surface bindings for this frame. For each registered MFD
+	// the client returns a SURFHANDLE holding the painted display and a spec
+	// identifying the mesh/group it should replace. When we hit (m, g) that
+	// matches, we bind the MFD surface instead of the group's base texture —
+	// same approach as D3D9Client's mesh->SetMFDScreenId(g, 1+mfd) plumbing.
+	struct MFDBinding { DWORD nmesh, ngroup; OGLSurface *surf; };
+	MFDBinding mfdBindings[MAXMFD];
+	int numMFDBindings = 0;
+	if (bVC && s_gc) {
+		for (int i = 0; i < MAXMFD; i++) {
+			const VCMFDSPEC *spec = nullptr;
+			SURFHANDLE s = s_gc->GetVCMFDSurface(i, &spec);
+			if (s && spec) {
+				mfdBindings[numMFDBindings].nmesh  = spec->nmesh;
+				mfdBindings[numMFDBindings].ngroup = spec->ngroup;
+				mfdBindings[numMFDBindings].surf   = (OGLSurface*)s;
+				numMFDBindings++;
+			}
+		}
+	}
+
 	// ----- Shadow pre-pass (PBR path only) ----------------------------------
 	// Render the vessel's meshes into the shared shadow depth map from the
 	// sun's point of view. Both passes work in the distance-normalised frame
@@ -480,7 +503,26 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 			// shader; the sampler itself still needs a traditional binding
 			// (GLSL 410 forbids opaque types in uniform blocks).
 			bool hasTexture = false;
-			if (grp && grp->TexIdx > 0 && grp->TexIdx <= nTex) {
+			OGLSurface *texOverride = nullptr;
+			if (internalpass && bVC) {
+				for (int k = 0; k < numMFDBindings; k++) {
+					if (mfdBindings[k].nmesh == m && mfdBindings[k].ngroup == g) {
+						texOverride = mfdBindings[k].surf;
+						break;
+					}
+				}
+			}
+			if (texOverride) {
+				GLuint texId = texOverride->GetTexture();
+				if (texId) {
+					glActiveTexture(GL_TEXTURE0);
+					glBindTexture(GL_TEXTURE_2D, texId);
+					GLint texLoc = s_shaderMgr->GetUniformLoc(activeShader,
+						activeShader == s_pbrShader ? "uDiffuseTex" : "uTexture");
+					glUniform1i(texLoc, 0);
+					hasTexture = true;
+				}
+			} else if (grp && grp->TexIdx > 0 && grp->TexIdx <= nTex) {
 				SURFHANDLE hSurf = oapiGetTextureHandle(hMesh, grp->TexIdx);
 				if (hSurf) {
 					OGLSurface *surf = (OGLSurface*)hSurf;

--- a/OVP/OGLClient/OGLvVessel.h
+++ b/OVP/OGLClient/OGLvVessel.h
@@ -16,6 +16,8 @@
 
 struct OGLTexture;
 
+namespace oapi { class GraphicsClient; }
+
 namespace ogl {
 
 class OGLEnvMap;
@@ -57,6 +59,11 @@ public:
 	// matHasEnvMap on whenever the pointer is non-null.
 	static void SetEnvMap(OGLEnvMap *env) { s_envMap = env; }
 
+	// Inject the GraphicsClient so the VC pass can query VC MFD/HUD surfaces
+	// via the virtual GetVCMFDSurface / GetVCHUDSurface methods. Called by
+	// OGLClient right after its OGLScene is up.
+	static void SetGraphicsClient(oapi::GraphicsClient *gc) { s_gc = gc; }
+
 	void Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &sunPos) override;
 
 private:
@@ -83,6 +90,7 @@ private:
 	static bool s_sharedInitialized;
 	static ShaderMgr *s_shaderMgr;
 	static OGLEnvMap *s_envMap;       // IBL environment (nullptr until scene bakes)
+	static oapi::GraphicsClient *s_gc; // client handle for VC MFD/HUD surface lookups
 
 	// GPU mesh cache lives in ogl::MeshRegistry now; see OGLMeshRegistry.h.
 	// Fallback mesh cache maps vessel class name to MESHHANDLE, used when

--- a/OVP/OGLClient/shaders/sketchpad.frag
+++ b/OVP/OGLClient/shaders/sketchpad.frag
@@ -1,0 +1,28 @@
+#version 410 core
+
+// Three render modes share one program so Sketchpad never has to swap
+// programs in the middle of a frame:
+//   0 = solid colour fill (Pen/Brush primitives)
+//   1 = textured modulate (CopyRect/StretchRect family)
+//   2 = alpha-mask text  (ImGui font atlas is single-channel alpha)
+in vec2 vUV;
+
+uniform vec4 uColor;
+uniform int  uMode;
+uniform sampler2D uTexture;
+
+out vec4 FragColor;
+
+void main() {
+    if (uMode == 0) {
+        FragColor = uColor;
+    } else if (uMode == 1) {
+        FragColor = texture(uTexture, vUV) * uColor;
+    } else {
+        // ImGui atlas: the glyph alpha sits in the r channel for the
+        // alpha-8 path and in a (as RGBA32) for the RGBA path. Sampling
+        // .a gives us the right mask in both cases.
+        float a = texture(uTexture, vUV).a;
+        FragColor = vec4(uColor.rgb, uColor.a * a);
+    }
+}

--- a/OVP/OGLClient/shaders/sketchpad.frag
+++ b/OVP/OGLClient/shaders/sketchpad.frag
@@ -1,13 +1,17 @@
 #version 410 core
 
-// Three render modes share one program so Sketchpad never has to swap
+// Render modes share one program so Sketchpad never has to swap
 // programs in the middle of a frame:
 //   0 = solid colour fill (Pen/Brush primitives)
 //   1 = textured modulate (CopyRect/StretchRect family)
 //   2 = alpha-mask text  (ImGui font atlas is single-channel alpha)
+//   3 = horizontal gradient (uColor .. uColor2, interpolated by vUV.x)
+//   4 = vertical gradient   (uColor .. uColor2, interpolated by vUV.y)
 in vec2 vUV;
 
 uniform vec4 uColor;
+uniform vec4 uColor2;       // gradient end colour (modes 3/4)
+uniform vec4 uColorKey;     // .rgb = key colour, .a = 1 enables discard
 uniform int  uMode;
 uniform sampler2D uTexture;
 
@@ -33,13 +37,22 @@ void main() {
     if (uMode == 0) {
         c = uColor;
     } else if (uMode == 1) {
-        c = texture(uTexture, vUV) * uColor;
-    } else {
+        vec4 tex = texture(uTexture, vUV);
+        if (uColorKey.a > 0.5) {
+            vec3 d = tex.rgb - uColorKey.rgb;
+            if (dot(d, d) < 1e-4) discard;
+        }
+        c = tex * uColor;
+    } else if (uMode == 2) {
         // ImGui atlas: the glyph alpha sits in the r channel for the
         // alpha-8 path and in a (as RGBA32) for the RGBA path. Sampling
         // .a gives us the right mask in both cases.
         float a = texture(uTexture, vUV).a;
         c = vec4(uColor.rgb, uColor.a * a);
+    } else if (uMode == 3) {
+        c = mix(uColor, uColor2, clamp(vUV.x, 0.0, 1.0));
+    } else {
+        c = mix(uColor, uColor2, clamp(vUV.y, 0.0, 1.0));
     }
 
     c *= uBrightness;

--- a/OVP/OGLClient/shaders/sketchpad.frag
+++ b/OVP/OGLClient/shaders/sketchpad.frag
@@ -8,12 +8,19 @@
 //   3 = horizontal gradient (uColor .. uColor2, interpolated by vUV.x)
 //   4 = vertical gradient   (uColor .. uColor2, interpolated by vUV.y)
 in vec2 vUV;
+in vec4 vWorldPos;
 
 uniform vec4 uColor;
 uniform vec4 uColor2;       // gradient end colour (modes 3/4)
 uniform vec4 uColorKey;     // .rgb = key colour, .a = 1 enables discard
 uniform int  uMode;
 uniform sampler2D uTexture;
+
+// World-space clip cones (Clipper). Each slot: .xyz direction, .w = 1
+// enables the check. uClipperCosDist[i].x = cos(half-angle),
+// uClipperCosDist[i].y = min distance beyond which the cone masks.
+uniform vec4 uClipperDir[2];
+uniform vec2 uClipperCosDist[2];
 
 // Per-draw colour transforms driven by SetBrightness / SetColorMatrix /
 // SetRenderParam. Defaults are identity so calling code that never
@@ -33,6 +40,19 @@ float pseudoNoise(vec2 p) {
 }
 
 void main() {
+    // World-space clip cones. Fragment is discarded when it falls inside
+    // either active cone beyond its near-distance; matches the D3D9
+    // Clipper() semantic used by planetarium "see-through" guards.
+    for (int i = 0; i < 2; i++) {
+        if (uClipperDir[i].w > 0.5) {
+            float d = length(vWorldPos.xyz);
+            if (d > uClipperCosDist[i].y) {
+                vec3 dir = normalize(vWorldPos.xyz);
+                if (dot(dir, uClipperDir[i].xyz) > uClipperCosDist[i].x) discard;
+            }
+        }
+    }
+
     vec4 c;
     if (uMode == 0) {
         c = uColor;

--- a/OVP/OGLClient/shaders/sketchpad.frag
+++ b/OVP/OGLClient/shaders/sketchpad.frag
@@ -11,18 +11,45 @@ uniform vec4 uColor;
 uniform int  uMode;
 uniform sampler2D uTexture;
 
+// Per-draw colour transforms driven by SetBrightness / SetColorMatrix /
+// SetRenderParam. Defaults are identity so calling code that never
+// touches them pays zero visual cost.
+uniform vec4 uBrightness;  // identity = (1,1,1,1)
+uniform mat4 uColorMat;    // identity
+uniform vec4 uGamma;       // rgb = 1/gamma exponent; identity = (1,1,1,_)
+uniform vec4 uNoise;       // rgb = noise tint, a = blend factor (0 = off)
+
 out vec4 FragColor;
 
+// Hash-based pseudo-random noise; deterministic in gl_FragCoord so the
+// same frame renders identically across redraws, which is what the D3D9
+// reference does (see SKP3_PRM_NOISE behaviour in Glare.hlsl).
+float pseudoNoise(vec2 p) {
+    return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
+
 void main() {
+    vec4 c;
     if (uMode == 0) {
-        FragColor = uColor;
+        c = uColor;
     } else if (uMode == 1) {
-        FragColor = texture(uTexture, vUV) * uColor;
+        c = texture(uTexture, vUV) * uColor;
     } else {
         // ImGui atlas: the glyph alpha sits in the r channel for the
         // alpha-8 path and in a (as RGBA32) for the RGBA path. Sampling
         // .a gives us the right mask in both cases.
         float a = texture(uTexture, vUV).a;
-        FragColor = vec4(uColor.rgb, uColor.a * a);
+        c = vec4(uColor.rgb, uColor.a * a);
     }
+
+    c *= uBrightness;
+    c = uColorMat * c;
+    c.rgb = pow(max(c.rgb, vec3(0.0)), uGamma.rgb);
+
+    if (uNoise.a > 0.0) {
+        float n = pseudoNoise(gl_FragCoord.xy);
+        c.rgb = mix(c.rgb, uNoise.rgb, uNoise.a * n);
+    }
+
+    FragColor = c;
 }

--- a/OVP/OGLClient/shaders/sketchpad.vert
+++ b/OVP/OGLClient/shaders/sketchpad.vert
@@ -1,0 +1,20 @@
+#version 410 core
+
+// 2D drawing for oapi::Sketchpad. Input is pixel coords in the bound
+// render-target's space (top-left origin); UV is only read when the
+// fragment shader samples a texture (text/blit modes).
+layout(location = 0) in vec2 aPos;
+layout(location = 1) in vec2 aUV;
+
+uniform vec2 uViewport;   // target width/height in pixels
+
+out vec2 vUV;
+
+void main() {
+    vec2 ndc = vec2(
+        aPos.x / uViewport.x * 2.0 - 1.0,
+        1.0 - aPos.y / uViewport.y * 2.0
+    );
+    gl_Position = vec4(ndc, 0.0, 1.0);
+    vUV = aUV;
+}

--- a/OVP/OGLClient/shaders/sketchpad.vert
+++ b/OVP/OGLClient/shaders/sketchpad.vert
@@ -6,15 +6,26 @@
 layout(location = 0) in vec2 aPos;
 layout(location = 1) in vec2 aUV;
 
-uniform vec2 uViewport;   // target width/height in pixels
+uniform vec2 uViewport;       // target width/height in pixels
+uniform mat4 uWorld;          // SetWorldTransform (identity by default)
+uniform mat4 uViewProj;       // active VP matrix when uViewMode == 1
+uniform int  uViewMode;       // 0 = pixel-space ORTHO, 1 = user VP
 
-out vec2 vUV;
+out vec2  vUV;
+out vec4  vWorldPos;          // passthrough for Clipper in fragment stage
 
 void main() {
-    vec2 ndc = vec2(
-        aPos.x / uViewport.x * 2.0 - 1.0,
-        1.0 - aPos.y / uViewport.y * 2.0
-    );
-    gl_Position = vec4(ndc, 0.0, 1.0);
+    vec4 wp = uWorld * vec4(aPos, 0.0, 1.0);
+    vWorldPos = wp;
+
+    if (uViewMode == 1) {
+        gl_Position = uViewProj * wp;
+    } else {
+        vec2 ndc = vec2(
+            wp.x / uViewport.x * 2.0 - 1.0,
+            1.0 - wp.y / uViewport.y * 2.0
+        );
+        gl_Position = vec4(ndc, 0.0, 1.0);
+    }
     vUV = aUV;
 }

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -2737,15 +2737,7 @@ void Orbiter::KbdInputBuffered_System (char *kstate, DIDEVICEOBJECTDATA *dod, DW
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgMap))               pDlgMgr->EnsureEntry<DlgMap>();
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgRecorder))          pDlgMgr->EnsureEntry<DlgRecorder>();
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_ToggleCamInternal)) {
-#ifdef _WIN32
 			SetView(g_focusobj, !g_camera->IsExternal());
-#else
-			// Only allow external views on macOS until cockpit rendering is fully implemented
-			if (g_camera->IsExternal())
-				fprintf(stderr, "[Orbiter] Cockpit view not yet supported on macOS\n");
-			else
-				SetView(g_focusobj, true); // switch to external
-#endif
 		}
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgVisHelper))         pDlgMgr->EnsureEntry<DlgOptions>()->SwitchPage("Visual helpers");
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgCapture))           pDlgMgr->EnsureEntry<DlgCapture>();


### PR DESCRIPTION
Chiude la Fase C del porting macOS ARM64 — virtual cockpit rendering, 2D panel cockpit, e parità 100% dell'API `oapi::Sketchpad` con Windows/D3D9.

## Sommario

| Milestone | Delta | Smoke |
|---|---|---|
| **M15** — Virtual Cockpit | F1 cockpit toggle riabilitato; mesh vismode + dual-pass render; MFD texture replacement; HUD overlay + click zones | ✅ |
| **M16** — 2D Panel | `clbkRender2DPanel` parità D3D9 (UsrFlag skip, MFD slot resolution, mesh-tex fallback) | ✅ |
| **M17** — Sketchpad | Root-cause fix (render nell'FBO della surface target, non ImGui overlay); colour transforms; blit family; transform stack + view/proj; clipping; mesh draw | ✅ |

Zero `TODO`/`FIXME`/`assert(false)` residui. Tutti i 58 virtual `assert(false)` di base di `oapi::Sketchpad` sono overridden con implementazione funzionale.

## Commit breakdown

**M15 — Virtual Cockpit (5 commit)**
- `93abc9c5` M15.a: re-enable F1 cockpit toggle on macOS
- `142b7cc1` M15.b: vessel mesh visibility filter + internal pass
- `862461bb` M15.c: VC MFD surface compositing on mesh groups
- `d31c6f7d` M15.d: VC HUD overlay + mouse click-zone verification
- `46090c8b` Roadmap: mark M15 done + log post-Fase C polish items

**M16 — 2D Panel (2 commit)**
- `9ee5e4f8` M16: 2D panel parity — UsrFlag skip, MFD slots, mesh-tex fallback
- `b33cd331` Roadmap: mark M16 done

**M17 — MFD Sketchpad (5 commit)**
- `417e4cf4` M17.a: Sketchpad renders into target surface FBO (root-cause fix)
- `0b51f8aa` M17.b: Sketchpad colour transforms (SetBrightness/ColorMatrix/RenderParam)
- `627d4b27` M17.c: Sketchpad blit / state / shape / text extras
- `438827bb` M17.d: Sketchpad transform stack, view/projection, clipping, mesh draw
- `e55a2bf6` Roadmap: mark M17 done + log post-Fase C Sketchpad polish

## Root-cause principale (M17.a)

Prima di M17.a l'`OGLSketchpad` usava `ImGui::GetForegroundDrawList()` e ignorava la `SURFHANDLE` passata — ogni draw andava sull'overlay screen globale (cleared ogni frame). `Instrument::Update` in `Src/Orbiter/Mfd.cpp:789` invoca `clbkGetSketchpad(surf)` aspettandosi che i draw materializzino contenuto nella texture RT del MFD: la nostra implementazione non scriveva mai su quella texture → MFD neri su macOS.

M17.a riscrive il render path: `OGLSketchpad` estratto in file dedicato, nuovo shader pair `sketchpad.vert/frag`, e ogni primitive rasterizza nell'FBO della surface target via `OGLSurface::BindFBO`. ImGui font atlas riutilizzato per glyph sampling (1 textured quad per glyph).

## Shader

`shaders/sketchpad.vert/frag` nuovi — 5 render mode (solid / textured / text / gradient horiz / gradient vert), 2 Clipper slot per cone di clip world-space, color transform uniforms (brightness/colormat/gamma/noise), chroma-key discard per `ColorKey()`, transform matrix pipeline (world + view*proj + ORTHO/USER mode switch).

## Files changed

```
MACOS_ROADMAP.md                     |   12 +-
OVP/OGLClient/CMakeLists.txt         |    1 +
OVP/OGLClient/OGLClient.cpp          |  234 +-----
OVP/OGLClient/OGLSketchpad.cpp       | 1416 ++++++++++++++++++++++++++++++++++
OVP/OGLClient/OGLSketchpad.h         |  295 +++++++
OVP/OGLClient/OGLvVessel.cpp         |  143 +++-
OVP/OGLClient/OGLvVessel.h           |    8 +
OVP/OGLClient/shaders/sketchpad.frag |   88 +++
OVP/OGLClient/shaders/sketchpad.vert |   31 +
Src/Orbiter/Orbiter.cpp              |    8 -
10 files changed, 2028 insertions(+), 208 deletions(-)
```

## Test plan

- [x] Build clean di `Orbiter` + `OGLClient` (AscentMFD link fail è pre-esistente su main — non causato da Fase C)
- [x] Smoke headless `Scenarios/test_simple`: PASS
- [x] Smoke headless `Scenarios/Delta-glider/Glass cockpit` (COCKPIT camera startup): PASS
- [x] Smoke headless `Scenarios/Delta-glider/Cape Canaveral`: PASS
- [x] Smoke headless `Scenarios/Delta-glider/Atmospheric autopilot`: PASS
- [x] Grep zero `TODO`/`FIXME`/`assert(false)` nei file Fase C
- [x] Cross-check: 58/58 virtual `assert(false)` base di `oapi::Sketchpad` overridden in `OGLSketchpad`
- [ ] **Interactive desktop acceptance** (registrata come follow-up non-bloccante in `MACOS_ROADMAP.md`):
  - F1 → VC mesh visibile, camera look-around mouse-drag
  - Shift+F1 → panel2d rendering con MFD populated
  - MFD trace: `Orbit` curva, `Map` coastline+terminator, `HSI` needle, `Docking` T-cross
  - LuaMFD con `SetBrightness`/`SetRenderParam(PRM_GAMMA)`
  - Pen width >1 su Apple M-series (triangle-quad fallback attivato)

## Follow-up non-bloccanti (registrati in MACOS_ROADMAP.md)

- M15 — Area compositing su texture DXT-compresse potrebbe necessitare decompress-on-first-area-bind
- M17 — Interactive desktop acceptance richiede human-in-the-loop (headless smoke non può verificare output visivo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)