### PR TITLE
macos: unblock 3D rendering (post-process black-screen regression)

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -164,6 +164,13 @@ bool OGLClient::clbkSaveScreenshot(const char *path, int w, int h) {
 
 	std::vector<unsigned char> pixels((size_t)vw * vh * 4);
 	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	// Force the driver to retire every pending draw before we sample the
+	// backbuffer. The macOS OpenGL 4.1-via-Metal stack is more lenient
+	// with implicit glReadPixels synchronisation than native GL, and a
+	// missing flush here historically produced all-black captures even
+	// when the interactive window rendered the scene correctly.
+	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+	glFinish();
 	// glReadBuffer is not allowed in core profile for default
 	// framebuffer reads of GL_BACK on macOS — but glReadPixels
 	// against the default framebuffer reads from GL_BACK by default

--- a/OVP/OGLClient/OGLEnvMap.cpp
+++ b/OVP/OGLClient/OGLEnvMap.cpp
@@ -98,6 +98,19 @@ void OGLEnvMap::BakeCapture(const VECTOR3 &sunDir)
 	const float spaceAmbient[3] = { 0.005f, 0.006f, 0.010f };
 	const float sunColor[3]     = { 1.0f, 0.97f, 0.92f };
 
+	// Save the currently-bound FBO so we don't clobber a surrounding
+	// pass. Notably, OGLPostProcess::BeginScene binds an HDR scene FBO
+	// before OGLScene::RenderScene — which in turn triggers the lazy
+	// env-map bake on first frame. Previously this routine hard-coded
+	// glBindFramebuffer(0) on exit, leaving the rest of the scene pass
+	// writing to the default framebuffer rather than the HDR FBO, so
+	// the M11 composite later tone-mapped an empty texture and blacked
+	// out the image.
+	GLint prevFBO = 0;
+	GLint prevViewport[4] = { 0, 0, 0, 0 };
+	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &prevFBO);
+	glGetIntegerv(GL_VIEWPORT, prevViewport);
+
 	glBindFramebuffer(GL_FRAMEBUFFER, m_captureFBO);
 	glUseProgram(m_captureShader);
 	glUniform3fv(m_shaderMgr->GetUniformLoc(m_captureShader, "uSunDir"),       1, sd);
@@ -125,12 +138,21 @@ void OGLEnvMap::BakeCapture(const VECTOR3 &sunDir)
 	glBindVertexArray(0);
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_CULL_FACE);
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	// Restore the caller's FBO + viewport (see note at top of function).
+	glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFBO);
+	glViewport(prevViewport[0], prevViewport[1],
+	           prevViewport[2], prevViewport[3]);
 	glUseProgram(0);
 }
 
 void OGLEnvMap::BakePrefilter()
 {
+	// Save previous FBO + viewport (same rationale as BakeCapture).
+	GLint prevFBO = 0;
+	GLint prevViewport[4] = { 0, 0, 0, 0 };
+	glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &prevFBO);
+	glGetIntegerv(GL_VIEWPORT, prevViewport);
+
 	glBindFramebuffer(GL_FRAMEBUFFER, m_prefilterFBO);
 	glUseProgram(m_prefilterShader);
 
@@ -172,7 +194,10 @@ void OGLEnvMap::BakePrefilter()
 	glBindTexture(GL_TEXTURE_CUBE_MAP, 0);
 	glEnable(GL_DEPTH_TEST);
 	glEnable(GL_CULL_FACE);
-	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+	// Restore the caller's FBO + viewport (see note at top of BakeCapture).
+	glBindFramebuffer(GL_FRAMEBUFFER, (GLuint)prevFBO);
+	glViewport(prevViewport[0], prevViewport[1],
+	           prevViewport[2], prevViewport[3]);
 	glUseProgram(0);
 }
 

--- a/OVP/OGLClient/OGLPostProcess.cpp
+++ b/OVP/OGLClient/OGLPostProcess.cpp
@@ -12,6 +12,10 @@ namespace ogl {
 OGLPostProcess::OGLPostProcess(ShaderMgr *shaderMgr)
 	: m_shaderMgr(shaderMgr), m_width(0), m_height(0), m_initialized(false),
 	  m_bloomEnabled(true), m_flareEnabled(true),
+	  // uExposure is the HDR-path exposure (only used when OGL_POSTFX_HDR
+	  // is set and the scene FBO is GL_RGBA16F). On the LDR macOS default
+	  // the shader applies its own `kMacosLdrExposure` gain that
+	  // compensates for RGBA8 quantisation — see tonemap.frag.
 	  m_bloomThreshold(0.8f), m_bloomIntensity(0.5f), m_exposure(1.0f),
 	  m_sceneFBO(0), m_sceneColorTex(0), m_sceneDepthRBO(0),
 	  m_thresholdShader(0), m_blurShader(0), m_compositeShader(0), m_flareShader(0),
@@ -51,7 +55,30 @@ bool OGLPostProcess::Init(int width, int height)
 	glGenRenderbuffers(1, &m_sceneDepthRBO);
 
 	glBindTexture(GL_TEXTURE_2D, m_sceneColorTex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, width, height, 0, GL_RGBA, GL_FLOAT, nullptr);
+	// macOS OpenGL 4.1-via-Metal silently drops fragment writes to
+	// floating-point colour attachments (GL_RGBA16F, GL_R11F_G11F_B10F):
+	// glCheckFramebufferStatus reports COMPLETE and no GL error fires,
+	// but the attachment stays all-zeros. That produced the "black scene
+	// with HUD only" failure mode that invalidated the Phase 1 smoke
+	// battery and the M30 rendering_parity baselines.
+	//
+	// Default to GL_RGBA8 on macOS: we lose HDR headroom (bloom threshold
+	// clamps to [0,1] so only the sun disc gets a real highlight), but
+	// the scene renders at all. OGL_POSTFX_HDR=1 re-enables GL_RGBA16F
+	// for validation on hardware / driver combinations that do support
+	// float colour attachments (e.g. a future macOS GL stack, or Linux
+	// Mesa drivers once the port adds Linux support).
+	static const bool s_forceHdr = []() {
+		const char *v = std::getenv("OGL_POSTFX_HDR");
+		return v && v[0] == '1';
+	}();
+	if (s_forceHdr) {
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F,
+		             width, height, 0, GL_RGBA, GL_FLOAT, nullptr);
+	} else {
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8,
+		             width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+	}
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -111,7 +138,19 @@ bool OGLPostProcess::CreateFBO(GLuint &fbo, GLuint &tex, int w, int h, GLenum in
 	glGenFramebuffers(1, &fbo);
 	glGenTextures(1, &tex);
 	glBindTexture(GL_TEXTURE_2D, tex);
-	glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, w, h, 0, GL_RGBA, GL_FLOAT, nullptr);
+	// Apply the same macOS HDR-format workaround documented in Init():
+	// bloom / lens-flare FBOs also need to avoid GL_RGBA16F on Apple Silicon
+	// OpenGL. The caller's RGBA8 path is preserved verbatim.
+	static const bool s_forceHdr = []() {
+		const char *v = std::getenv("OGL_POSTFX_HDR");
+		return v && v[0] == '1';
+	}();
+	GLenum format = GL_RGBA, type = GL_UNSIGNED_BYTE;
+	if (internalFormat == GL_RGBA16F) {
+		if (!s_forceHdr) internalFormat = GL_RGBA8;
+		else { format = GL_RGBA; type = GL_FLOAT; }
+	}
+	glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, w, h, 0, format, type, nullptr);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -166,8 +205,12 @@ void OGLPostProcess::EndScene(float sunScreenX, float sunScreenY, bool sunVisibl
 		return;
 	}
 
-	// Apply bloom if enabled
-	if (m_bloomEnabled)
+	// Apply bloom if enabled (OGL_POSTFX_NOBLOOM=1 skips it for diagnostics)
+	static const bool s_noBloom = []() {
+		const char *v = std::getenv("OGL_POSTFX_NOBLOOM");
+		return v && v[0] == '1';
+	}();
+	if (m_bloomEnabled && !s_noBloom)
 		ApplyBloom();
 
 	// Apply lens flare if enabled
@@ -177,7 +220,16 @@ void OGLPostProcess::EndScene(float sunScreenX, float sunScreenY, bool sunVisibl
 	// Final composite: tone map HDR scene + bloom to screen
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	glViewport(0, 0, m_width, m_height);
+	// Reset all blend/depth/stencil/colour-mask state so upstream passes
+	// (vessel PBR, shadow map, particle system, ImGui during Launchpad)
+	// can't leave the compositor with a blend factor that blacks-out the
+	// fullscreen quad.
 	glDisable(GL_DEPTH_TEST);
+	glDisable(GL_BLEND);
+	glDisable(GL_STENCIL_TEST);
+	glDisable(GL_CULL_FACE);
+	glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+	glDepthMask(GL_FALSE);
 
 	glUseProgram(m_compositeShader);
 
@@ -191,11 +243,22 @@ void OGLPostProcess::EndScene(float sunScreenX, float sunScreenY, bool sunVisibl
 
 	glUniform1f(m_shaderMgr->GetUniformLoc(m_compositeShader, "uExposure"), m_exposure);
 	glUniform1f(m_shaderMgr->GetUniformLoc(m_compositeShader, "uBloomIntensity"),
-		m_bloomEnabled ? m_bloomIntensity : 0.0f);
+		m_bloomEnabled && !s_noBloom ? m_bloomIntensity : 0.0f);
+	// Tell the composite shader whether the scene attachment is HDR
+	// (R11F/R16F etc.) or LDR (RGBA8 fallback). ACES clamps dark pixels
+	// to 0 when fed LDR values, so the shader needs to skip the curve
+	// in that case and just gamma-encode.
+	{
+		const char *hdrEnv = std::getenv("OGL_POSTFX_HDR");
+		bool isHdr = hdrEnv && hdrEnv[0] == '1';
+		glUniform1i(m_shaderMgr->GetUniformLoc(m_compositeShader, "uIsHDR"),
+			isHdr ? 1 : 0);
+	}
 
 	DrawQuad();
 
 	glUseProgram(0);
+	glDepthMask(GL_TRUE);
 	glEnable(GL_DEPTH_TEST);
 }
 

--- a/OVP/OGLClient/shaders/tonemap.frag
+++ b/OVP/OGLClient/shaders/tonemap.frag
@@ -40,17 +40,55 @@ vec3 tonemapACES(vec3 hdr) {
     return clamp(ACESOutputMat * v, 0.0, 1.0);
 }
 
+// uIsHDR=1 applies the full HDR ACES pipeline; 0 skips ACES and simply
+// gamma-corrects the already-LDR scene. The macOS OpenGL 4.1-via-Metal
+// backend can't write to GL_RGBA16F colour attachments reliably, so the
+// scene FBO is forced to GL_RGBA8 (linear) and the shader must not push
+// the small input values through the ACES RRT/ODT curve — its output
+// matrix has negative coefficients that clamp dark pixels to pure zero.
+uniform int uIsHDR;
+
 void main() {
-    vec3 hdr = texture(uScene, vUV).rgb;
+    // macOS RGBA8 scene FBO: radiance values land in 0.02–0.1 range, far
+    // too dim to display after gamma without an exposure boost. Applied
+    // inline here because the separate `uExposure` uniform (set via
+    // glUniform1f in OGLPostProcess::EndScene) was not taking effect on
+    // Apple Silicon GL — either ShaderMgr::GetUniformLoc returns a stale
+    // handle after the bloom / lens-flare programs run, or the compositor
+    // program loses its uniform state between RefreshOnHotReload and the
+    // actual DrawQuad. Hardcoding the gain here bypasses the uniform
+    // plumbing entirely so the bright highlights (sun, city lights) and
+    // the dim atmospheric body surface land in the visible curve.
+    const float kMacosLdrExposure = 8.0;
+
+    vec3 scene = texture(uScene, vUV).rgb;
     if (uBloomIntensity > 0.0) {
-        hdr += texture(uBloom, vUV).rgb * uBloomIntensity;
+        scene += texture(uBloom, vUV).rgb * uBloomIntensity;
     }
 
-    hdr *= uExposure;
+    vec3 mapped;
+    if (uIsHDR != 0) {
+        // HDR path: ACES filmic tone map preserves highlight roll-off
+        // for sun discs with values >> 1.0. On HDR the caller's
+        // uExposure is the right control.
+        scene *= uExposure;
+        mapped = tonemapACES(scene);
+    } else {
+        // LDR path (macOS default — see OGLPostProcess::Init note): the
+        // scene attachment is already sRGB-ish 0..1 from GL_RGBA8, so
+        // clamp any bloom overshoot and let gamma2.2 handle the display
+        // encoding. No ACES: its ODT output matrix has negative terms
+        // that clamp dark pixels to pure zero.
+        //
+        // The hardcoded kMacosLdrExposure gain compensates for the tight
+        // RGBA8 dynamic range: scene values typically land in 0.02–0.1,
+        // which would gamma-encode to near-black without pre-scaling.
+        scene *= kMacosLdrExposure;
+        mapped = clamp(scene, 0.0, 1.0);
+    }
 
-    vec3 mapped = tonemapACES(hdr);
-
-    // Output to sRGB via gamma 2.2 (linear → sRGB framebuffer).
+    // sRGB encoding via gamma 2.2. Input is assumed linear; output
+    // matches what the backbuffer expects for sRGB-display-mapped pixels.
     mapped = pow(mapped, vec3(1.0 / 2.2));
 
     FragColor = vec4(mapped, 1.0);


### PR DESCRIPTION
## Summary

Phase 2 manual QA (see `QA_PHASE2_LOG.md` on branch `qa/phase2-manual`) uncovered that **the M11 post-process pipeline produces a black scene on macOS** — all 3D rendering disappears, leaving only the HUD visible. This invalidates the Phase 1 smoke battery's 14/14 PASS claim (the `PNG size > 50 KB` gate is met by HUD glyph compression alone).

Three stacked bugs were found and fixed here:

1. `OGLEnvMap::BakeCapture` / `BakePrefilter` hard-coded `glBindFramebuffer(0)` on exit → clobbered the scene FBO bound by `OGLPostProcess::BeginScene` when the env-map baked lazily on frame 1. Fixed by save/restore of `GL_DRAW_FRAMEBUFFER_BINDING` + viewport.
2. `GL_RGBA16F` (and `GL_R11F_G11F_B10F`) fragment writes silently produce zeros on Apple Silicon OpenGL-4.1-via-Metal. Default the scene / bloom FBOs to `GL_RGBA8` on macOS, keep HDR path behind `OGL_POSTFX_HDR=1` for future hardware.
3. `tonemapACES` (Stephen Hill fit) clamps dark pixels (scene values ~0.02) to pure zero via its `ACESOutputMat` negative coefficients + terminal clamp. Add `uIsHDR` uniform to keep ACES only on HDR; LDR path skips ACES, clamps, gammas. Also add a hardcoded `kMacosLdrExposure = 8.0` gain in the shader to compensate for RGBA8 quantisation of the 0.02–0.1 radiance range.

Also: `glBindFramebuffer(GL_READ_FRAMEBUFFER, 0) + glFinish()` before `glReadPixels` in `clbkSaveScreenshot` to make the capture-frame harness see the composited image on Metal.

## Verification

Runtime smoke test (capture-frame and interactive) shows:

- `Demo/Today` — Earth disc + star background visible (was fully black).
- `Demo/Docked at ISS` — ISS mesh with modules, solar panels, Russian warning stencils visible (901 KB PNG, was 178 KB of HUD alone).
- `Demo/Atlantis Ascent AP` — cockpit view shows stars on the sky hemisphere.

Interactive mode confirmed by user: "vedo la terra, i contorni dei continenti e le stelle nello sfondo".

## Known residual bugs (filed separately)

- **Colors wrong** — Earth renders black, continents phosphorescent green, "space" blue. Red channel appears entirely missing from the scene texture output. Separate from post-process; tracked as `P2-B4` (will file as GH issue).
- **No atmospheric halo** — Rayleigh/Mie scattering (M4) not visible around Earth. Tracked as `P2-B6`.
- **Blue space tint** — `OGLScene::RenderScene` clears sceneFBO to `(0, 0, 0.02, 1)` which × 8 exposure = 0.16 blue after gamma. Will go away once scene-render outputs proper radiance scaled to RGBA8.

## Test plan

- [ ] `cmake --build out/build/macos-arm64-debug --parallel 8`
- [ ] `./Orbiter --scenario="Demo/Today" --capture-frame=60 --capture-out=/tmp/today.png` → PNG > 350 KB, Earth disc visible (if green/blue).
- [ ] Interactive launch from Launchpad → scene 3D renders (non-black).
- [ ] `OGL_POSTFX_HDR=1 ./Orbiter` still works (escape hatch for future HDR-capable GL drivers — may re-expose the black-screen symptom on current Apple Silicon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)