### PR TITLE
macos: fix plugin InitModule systemic failure

### DIFF
--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -669,6 +669,18 @@ HRESULT Orbiter::Create (HINSTANCE hInstance)
 #else
 	LoadModules("Modules/Plugin", pConfig->CfgCmdlinePrm.LoadPlugins);
 	LoadModules("Modules/Plugin", pConfig->GetActiveModules());
+
+	// macOS / Linux: Register the built-in Launchpad Extra items
+	// (Physics / Instruments / Vessel configuration / Planet configuration /
+	// Debug containers + their leaf items) into LaunchpadRegistry BEFORE
+	// the startup plugins load — otherwise plugins that call
+	// oapiFindLaunchpadItem("Vessel configuration") from their InitModule
+	// (e.g. AtlantisConfig) find the registry empty, receive NULL parent,
+	// and their registration results in orphan items that never render in
+	// the Extra tab tree. The function is idempotent (early-out if
+	// s_items is non-empty) so a later re-call when the Launchpad UI is
+	// about to draw is a safe no-op.
+	orbiter::RegisterBuiltinLaunchpadItems(pConfig);
 #endif
 
 	// preload startup plugin modules

--- a/Src/Orbitersdk/Orbitersdk.cpp
+++ b/Src/Orbitersdk/Orbitersdk.cpp
@@ -46,24 +46,43 @@ BOOL WINAPI DllMain (HINSTANCE hModule,
 #else
 // On POSIX platforms, use constructor/destructor attributes instead of DllMain
 static void (*s_DLLExit)(HINSTANCE) = nullptr;
+static HMODULE s_selfHandle = nullptr;
+
+// Resolve the handle for THIS module (the dylib that contains
+// posix_module_init). Orbiter::LoadModule dlopen()s plugins with
+// RTLD_LOCAL, so `dlsym(RTLD_DEFAULT, "InitModule")` can't see a
+// plugin's own InitModule — the symbol is confined to the local
+// namespace. We need a handle that points at THIS dylib so
+// InitLib's GetProcAddress call resolves against the caller.
+//
+// Strategy: dladdr() on a function pointer we know lives inside this
+// dylib tells us the backing file path; dlopen(RTLD_NOLOAD) then
+// returns the existing handle without re-loading the file.
+static HMODULE resolve_self_handle() {
+	Dl_info info{};
+	if (!dladdr((void*)&resolve_self_handle, &info) || !info.dli_fname) {
+		return nullptr;
+	}
+	// RTLD_NOLOAD: do not load; return handle iff the file is already mapped.
+	return (HMODULE)dlopen(info.dli_fname, RTLD_NOW | RTLD_NOLOAD);
+}
 
 __attribute__((constructor))
 static void posix_module_init() {
 	OAPIFUNC void InitLib (HINSTANCE hModule);
-	InitLib(nullptr);
+	s_selfHandle = resolve_self_handle();
+	InitLib(s_selfHandle);
 
-	// Find ExitModule via dlsym on the current module
-	void* self = dlopen(nullptr, RTLD_NOW);
-	if (self) {
-		s_DLLExit = (void(*)(HINSTANCE))dlsym(self, "ExitModule");
-		if (!s_DLLExit) s_DLLExit = (void(*)(HINSTANCE))dlsym(self, "opcDLLExit");
-		dlclose(self);
+	if (s_selfHandle) {
+		s_DLLExit = (void(*)(HINSTANCE))dlsym(s_selfHandle, "ExitModule");
+		if (!s_DLLExit) s_DLLExit = (void(*)(HINSTANCE))dlsym(s_selfHandle, "opcDLLExit");
 	}
 }
 
 __attribute__((destructor))
 static void posix_module_fini() {
-	if (s_DLLExit) s_DLLExit(nullptr);
+	if (s_DLLExit) s_DLLExit(s_selfHandle);
+	if (s_selfHandle) dlclose(s_selfHandle);
 }
 #endif
 


### PR DESCRIPTION
## Summary

Phase 2 manual QA (`QA_PHASE2_LOG.md` finding P2-B12) uncovered that **every startup plugin's `InitModule` was being silently skipped on macOS**. The Launchpad Extra tab's "Vessel configuration" container, documented as hosting `AtlantisConfig` in Phase 1 §B.2 + M22.g follow-up, appeared empty.

Two independent bugs stacked:

### Bug 1 — Registry order

`Src/Orbiter/Orbiter.cpp:675` called `LoadStartupModules()` BEFORE `RegisterBuiltinLaunchpadItems(pConfig)` (which ran only later at `:1340`, guarded by the Launchpad-about-to-open branch). `AtlantisConfig::InitModule` invoked `oapiFindLaunchpadItem("Vessel configuration")` against an empty registry and got `NULL` for its parent.

### Bug 2 — POSIX plugin bootstrap used `nullptr` handle

`Src/Orbitersdk/Orbitersdk.cpp` (linked into every addon dylib as the Win32-`DllMain` equivalent) called `InitLib(nullptr)` from its `__attribute__((constructor))`. `InitLib` then did `GetProcAddress(hModule, "InitModule")` → `dlsym(nullptr, "InitModule")` → `RTLD_DEFAULT`, which only walks globally-exposed symbols. Orbiter `dlopen()`s plugins with `RTLD_LOCAL`, so each plugin's own `InitModule` is confined to its private namespace and **not visible via `RTLD_DEFAULT`**. Result: `InitLib` silently found nothing to call, every startup plugin skipped its registration phase.

This affected every plugin that ran setup code in `InitModule`: `AtlantisConfig` (the visible symptom), `AtmConfig`, and likely the MFD-registering plugins (`AscentMFD`, `TransX`, `LuaMFD`, `ScriptMFD`, etc.) once they're active.

## Fix

- **Orbiter.cpp**: call `RegisterBuiltinLaunchpadItems(pConfig)` right after the `Modules/Plugin` load on the POSIX branch, before `LoadStartupModules()`. The function is idempotent (it early-outs when `s_items` is non-empty), so the later call at `:1340` is a safe no-op.

- **Orbitersdk.cpp**: resolve the current dylib's handle via `dladdr(&resolve_self_handle) + dlopen(RTLD_NOLOAD)` in the constructor, and hand it to `InitLib`. The destructor uses the same handle for `ExitModule`/`opcDLLExit` symmetry.

## Verification

With the fix applied:

```
[OGLLaunchpad] Registered 15 built-in Extra items
[AtlantisConfig] InitModule: root handle = 0x3 for 'Vessel configuration'
[AtlantisConfig] InitModule: RegisterLaunchpadItem → 0x10
```

Interactive Launchpad Extra tab (Phase 2 STEP 1.6a) now shows `Atlantis Configuration` under `Vessel configuration` with an `Edit...` affordance wired to the `clbkRender` editor. `Atmosphere Configuration` also appears as a top-level item (AtmConfig was affected too).

## Test plan

- [ ] `cmake --build out/build/macos-arm64-debug --parallel 8`
- [ ] `./Orbiter` → Launchpad Extra tab → `Vessel configuration` expandable → `Atlantis Configuration` child present
- [ ] Atmosphere Configuration top-level item also present
- [ ] Click AtlantisConfig → right pane shows description + `Edit...` button → opens modal with texture/mesh high-res toggles
- [ ] No regression in Win32 build (the fixes only touch the POSIX code paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)