### PR TITLE
macos: fix Ctrl+S Quicksave Win32 backslash path leak

### DIFF
--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -1922,9 +1922,18 @@ VOID Orbiter::Quicksave ()
 	int i;
 	char desc[256], fname[256];
 	sprintf (desc, "Orbiter saved state at T = %0.0f", td.SimT0);
+#ifdef _WIN32
+	const char sep = '\\';
+#else
+	const char sep = '/';
+#endif
 	for (i = strlen(ScenarioName)-1; i > 0; i--)
-		if (ScenarioName[i-1] == '\\') break;
+		if (ScenarioName[i-1] == sep) break;
+#ifdef _WIN32
 	sprintf (fname, "Quicksave\\%s %04d", ScenarioName+i, ++g_qsaveid);
+#else
+	sprintf (fname, "Quicksave/%s %04d", ScenarioName+i, ++g_qsaveid);
+#endif
 	if(SaveScenario (fname, desc, 0))
 		oapiAddNotification(OAPINOTIF_SUCCESS, "Scenario saved successfully", fname);
 	else


### PR DESCRIPTION
## Summary

Phase 2 manual QA STEP 8 (`QA_PHASE2_LOG.md` P2-B23) exposed a Win32 path-separator leak in `Orbiter::Quicksave` (`Src/Orbiter/Orbiter.cpp:1917-1932`). The save filename was built with a hard-coded backslash (both the last-segment scan `ScenarioName[i-1] == '\\'` and the format string `"Quicksave\\%s %04d"`). On POSIX filesystems that produces a path like `"Quicksave\Demo/Today 0002"` which cannot be created; the save fails and the user sees a `"Failed to save scenario: Quicksave\Demo/Today 0002"` notification.

Same pattern as the earlier `CELBODY2::LoadAtmosphereModule` atmosphere-path fix (Phase 1 B3).

## Fix

Gate both the separator constant and the prefix format string with `#ifdef _WIN32`. POSIX uses `/`; Win32 behaviour is unchanged.

```cpp
#ifdef _WIN32
    const char sep = '\\';
#else
    const char sep = '/';
#endif
```

## Verification

After applying the fix, Ctrl+S in a running scenario (Demo/Today) no longer surfaces the failure notification. The quicksave writes the expected file under `~/Library/Application Support/Orbiter/Scenarios/Quicksave/` (via the M26 UserPaths pipeline).

## Test plan

- [ ] Launch Demo/Today → press Ctrl+S → success notification
- [ ] Launchpad → Scenarios → Quicksave → saved scenario visible and re-loadable
- [ ] Win32 build unaffected (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)