### PR TITLE
macos: fix ShaderMgr cache collision regressing DG 2D panel (#37)

### DIFF
--- a/OVP/OGLClient/OGLShaderMgr.cpp
+++ b/OVP/OGLClient/OGLShaderMgr.cpp
@@ -111,7 +111,7 @@ GLuint ShaderMgr::LoadProgram(const char *name, const char *vertFile, const char
 
 GLint ShaderMgr::GetUniformLoc(GLuint program, const char *name)
 {
-	uint64_t key = ((uint64_t)program << 32) | (uint64_t)std::hash<std::string>{}(name);
+	std::pair<GLuint, std::string> key(program, name);
 	auto it = m_uniforms.find(key);
 	if (it != m_uniforms.end())
 		return it->second;
@@ -252,7 +252,7 @@ bool ShaderMgr::ReloadProgram(ProgramEntry &entry)
 
 	// Remove uniform cache entries that belonged to the old program.
 	for (auto it = m_uniforms.begin(); it != m_uniforms.end(); ) {
-		if ((GLuint)(it->first >> 32) == old)
+		if (it->first.first == old)
 			it = m_uniforms.erase(it);
 		else
 			++it;

--- a/OVP/OGLClient/OGLShaderMgr.h
+++ b/OVP/OGLClient/OGLShaderMgr.h
@@ -124,8 +124,12 @@ private:
 	// Key = logical program name.
 	std::map<std::string, ProgramEntry> m_programs;
 
-	// Key = (program << 32) | hash(name). Invalidated on reload.
-	std::map<uint64_t, GLint> m_uniforms;
+	// Uniform-location cache. Key is a (program, name) pair so different
+	// programs that share uniform names (e.g. "uAlpha") never alias.
+	// Invalidated per-program on hot-reload. The previous uint64-packed
+	// key OR-merged the hash into the program slot and returned stale
+	// locations across programs — regressed panel2d (#37).
+	std::map<std::pair<GLuint, std::string>, GLint> m_uniforms;
 
 	// UBO block-name → binding point. Populated via RegisterUBOBinding()
 	// plus defaults seeded in the constructor.


### PR DESCRIPTION
## Summary
- Root cause: `ShaderMgr::GetUniformLoc` cached uniform locations under a uint64 key built as `(program << 32) | hash(name)`. `std::hash<std::string>` is 64-bit on Darwin, so its upper bits collided with the program slot and the cache returned a stale location for uniforms whose name is shared across programs (`uAlpha`, `uTexture`, `uTransform`, …).
- Concretely for panel2d: `glUniform1f(locAlpha, 1.0)` was writing to the wrong location, the real `uAlpha` stayed at its default 0, and every panel fragment got `texture(...) * 0` in the alpha channel → DeltaGlider 2D panel rendered fully transparent (Phase-2 attribute to #37 "cockpit empty").
- Fix switches the cache to a proper `std::pair<GLuint, std::string>` key (and updates the per-program hot-reload invalidation to match). One-call-site change, 2 files, +8/-4.

Before (pre-fix) / after (post-fix) screenshots in the issue thread for `Demo/Docked at ISS`. After the fix the full DG dashboard — ADI, MFDs, altimeter, radar scope, propellant status, RCS readouts — renders identically to the DX9 reference.

Also unblocks the MFD-plugin testing that Phase 2 marked as SKIPPED (once F1 is usable the MFD bezels/displays are interactable again).

Note: this does **not** fix the VC mesh texturing issue seen in `Demo/Virtual cockpit` — that path goes through `OGLvVessel::Render` with VCMFDSurface binding and needs separate investigation. 2D panel path (the dominant one for DG/Shuttle/etc.) is now fully working.

Fixes #37

## Test plan
- [x] `Demo/Docked at ISS` capture-frame=60 shows full DG panel with instruments visible
- [x] `Demo/Today` external view unchanged (still affected by #25 red-channel bug, not regressed)
- [x] `Demo/Virtual cockpit` VC mode: partial VC mesh still as before, no regression
- [x] Shader hot-reload path still invalidates correctly (per-program)
- [ ] Interactive smoke: launch → Demo/Docked at ISS → F1 → verify instruments visible and interactable

🤖 Generated with [Claude Code](https://claude.com/claude-code)