### PR TITLE
macos: fix DlgMap empty (4 stacked bugs)

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -425,6 +425,18 @@ SURFHANDLE OGLClient::clbkCreateSurfaceEx(DWORD w, DWORD h, DWORD attrib)
 	return (SURFHANDLE)surf;
 }
 
+// Plain 2-arg overload used by oapiCreateSurface(w,h). Legacy Orbiter API —
+// callers (VectorMap, DlgMap, MFD panels, various vessel modules) expect a
+// render-target texture they can feed into Sketchpad and later show via
+// ImGui or blit as a mesh texture. Without this override the base class
+// returned NULL and DlgMap stayed empty (#39).
+SURFHANDLE OGLClient::clbkCreateSurface(DWORD w, DWORD h, SURFHANDLE /*hTemplate*/)
+{
+	if (w == 0 || h == 0) return nullptr;
+	return clbkCreateSurfaceEx(w, h,
+		OAPISURFACE_TEXTURE | OAPISURFACE_RENDERTARGET | OAPISURFACE_SKETCHPAD);
+}
+
 bool OGLClient::clbkGetSurfaceSize(SURFHANDLE surf, DWORD *w, DWORD *h)
 {
 	if (!surf) { *w = *h = 0; return false; }

--- a/OVP/OGLClient/OGLClient.h
+++ b/OVP/OGLClient/OGLClient.h
@@ -58,6 +58,7 @@ public:
 	void clbkReleaseTexture(SURFHANDLE hTex) override;
 	bool clbkReleaseSurface(SURFHANDLE surf) override;
 	SURFHANDLE clbkCreateSurfaceEx(DWORD w, DWORD h, DWORD attrib) override;
+	SURFHANDLE clbkCreateSurface(DWORD w, DWORD h, SURFHANDLE hTemplate = NULL) override;
 	bool clbkGetSurfaceSize(SURFHANDLE surf, DWORD *w, DWORD *h) override;
 	void clbkIncrSurfaceRef(SURFHANDLE surf) override;
 	bool clbkSetSurfaceColourKey(SURFHANDLE surf, DWORD ckey) override;

--- a/Src/Orbiter/DlgMap.cpp
+++ b/Src/Orbiter/DlgMap.cpp
@@ -10,6 +10,7 @@
 #include "Celbody.h"
 #include "Psys.h"
 #include "imgui.h"
+#include "imgui_extras.h"
 #include "IconsFontAwesome6.h"
 #include "DlgInfo.h"
 
@@ -255,8 +256,11 @@ void DlgMap::DrawMap() {
             vectormap->DrawMap ();
         }
 
-        ImVec2 uv_min = ImVec2(0.0f, 0.0f);                 // Top-left
-        ImVec2 uv_max = ImVec2(1.0f, 1.0f);                 // Lower-right
+        // OpenGL FBO stores pixel row 0 at the bottom of the texture, while
+        // ImGui expects row 0 at the top. Flip the V coordinate so the map
+        // displays right-side-up (#39).
+        ImVec2 uv_min = ImVec2(0.0f, 1.0f);
+        ImVec2 uv_max = ImVec2(1.0f, 0.0f);
         ImVec4 tint_col = ImVec4(1.0f, 1.0f, 1.0f, 1.0f);   // No tint
         ImVec4 border_col = ImVec4(0.0f, 0.0f, 0.0f, 0.0f); // 50% opaque white
 

--- a/Src/Orbiter/VectorMap.cpp
+++ b/Src/Orbiter/VectorMap.cpp
@@ -101,6 +101,10 @@ void VectorMap::InitGDIResources ()
 	// for default label size, query screen resolution
 	int screenh = GetSystemMetrics(SM_CYSCREEN);
 	labelsize = screenh / 100;
+	// On macOS GetSystemMetrics() is a stub returning 0; without this fallback
+	// labelsize becomes 0, oapiCreateFont(-0,...) yields a zero-height font
+	// and ImGui aborts when DrawMarker/Text tries to lay out a glyph (#39).
+	if (labelsize < 8) labelsize = 14;
 	SetLabelSize(labelsize);
  
 	penGridline = oapiCreatePen(1, 1, 0x505050);


### PR DESCRIPTION
## Summary
DlgMap (Ctrl+M) was completely empty on macOS. Four independent bugs needed fixing in sequence — each one was hidden behind the previous:

1. **`OGLClient::clbkCreateSurface(w, h, hTemplate)` missing.** Only the `Ex` overload was overridden, so `oapiCreateSurface(w, h)` from `VectorMap::SetCanvas` fell through to the base-class stub (returns NULL). No target surface → nothing to draw into.

2. **`DlgMap.cpp` missed the Orbiter ImGui extras header.** The call site saw only the standard `ImGui::ImageButton(..., ImTextureRef, ...)`. The `ImTextureRef(void*)` constructor happily cast the SURFHANDLE pointer straight into a GL texture ID — an integer with no matching texture. On macOS that rendered as the ImGui window frame color (bright green).

3. **`GetSystemMetrics(SM_CYSCREEN)` returns 0 on macOS (stubbed).** `VectorMap::InitGDIResources` derived `labelsize = screenh / 100`, got 0, and created a zero-height font. The first call to `OGLSketchpad::Text` from `DrawMarker` then tripped an ImGui assert → SIGABRT.

4. **FBO↔ImGui V-axis mismatch.** Once the map actually drew, it came out upside-down. OpenGL FBOs store pixel row 0 at the bottom; ImGui expects row 0 at the top. Flipped the V coordinate in the `ImageButton` call.

After all four the map renders correctly: coastlines, grid, terminator, base markers, vessel crosses with readable labels, orbit groundtrack. Screenshot in the issue thread.

The overall green tint on the day-shade brush is the planet red-channel bug ([#25](https://github.com/kanik0/orbiter/issues/25)), not introduced here and explicitly called out in the acceptance criteria.

## Test plan
- [x] Demo/Today → Ctrl+M: map shows coastlines + grid + vessel markers (ISS, GL-01, SH-01, Mir) with legible labels
- [x] Map is right-side-up (continents + text in correct orientation)
- [x] No crash in `OGLSketchpad::Text` when vessel labels render
- [x] Diff is minimal (+23/-2 across 4 files) — pure fix, no refactors

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)