### PR TITLE
macos: drop 8× LDR exposure workaround (textured planets render naturally)

### DIFF
--- a/OVP/OGLClient/OGLPostProcess.cpp
+++ b/OVP/OGLClient/OGLPostProcess.cpp
@@ -12,10 +12,13 @@ namespace ogl {
 OGLPostProcess::OGLPostProcess(ShaderMgr *shaderMgr)
 	: m_shaderMgr(shaderMgr), m_width(0), m_height(0), m_initialized(false),
 	  m_bloomEnabled(true), m_flareEnabled(true),
-	  // uExposure is the HDR-path exposure (only used when OGL_POSTFX_HDR
-	  // is set and the scene FBO is GL_RGBA16F). On the LDR macOS default
-	  // the shader applies its own `kMacosLdrExposure` gain that
-	  // compensates for RGBA8 quantisation — see tonemap.frag.
+	  // uExposure controls both paths. Default 1.0 passes the scene through
+	  // without added gain; textured planets (Saturn, Venus, Mercury, Dione)
+	  // render at their natural albedo. The previous 8× LDR workaround was
+	  // needed because uExposure didn't actually reach the shader on macOS
+	  // (ShaderMgr cache collision, fixed by #49) — it has been removed now
+	  // that the uniform plumbing lands correctly. Caller can override via
+	  // SetExposure() for HDR scenes or user preference.
 	  m_bloomThreshold(0.8f), m_bloomIntensity(0.5f), m_exposure(1.0f),
 	  m_sceneFBO(0), m_sceneColorTex(0), m_sceneDepthRBO(0),
 	  m_thresholdShader(0), m_blurShader(0), m_compositeShader(0), m_flareShader(0),

--- a/OVP/OGLClient/shaders/tonemap.frag
+++ b/OVP/OGLClient/shaders/tonemap.frag
@@ -49,18 +49,6 @@ vec3 tonemapACES(vec3 hdr) {
 uniform int uIsHDR;
 
 void main() {
-    // macOS RGBA8 scene FBO: radiance values land in 0.02–0.1 range, far
-    // too dim to display after gamma without an exposure boost. Applied
-    // inline here because the separate `uExposure` uniform (set via
-    // glUniform1f in OGLPostProcess::EndScene) was not taking effect on
-    // Apple Silicon GL — either ShaderMgr::GetUniformLoc returns a stale
-    // handle after the bloom / lens-flare programs run, or the compositor
-    // program loses its uniform state between RefreshOnHotReload and the
-    // actual DrawQuad. Hardcoding the gain here bypasses the uniform
-    // plumbing entirely so the bright highlights (sun, city lights) and
-    // the dim atmospheric body surface land in the visible curve.
-    const float kMacosLdrExposure = 8.0;
-
     vec3 scene = texture(uScene, vUV).rgb;
     if (uBloomIntensity > 0.0) {
         scene += texture(uBloom, vUV).rgb * uBloomIntensity;
@@ -69,21 +57,18 @@ void main() {
     vec3 mapped;
     if (uIsHDR != 0) {
         // HDR path: ACES filmic tone map preserves highlight roll-off
-        // for sun discs with values >> 1.0. On HDR the caller's
-        // uExposure is the right control.
+        // for sun discs with values >> 1.0.
         scene *= uExposure;
         mapped = tonemapACES(scene);
     } else {
-        // LDR path (macOS default — see OGLPostProcess::Init note): the
-        // scene attachment is already sRGB-ish 0..1 from GL_RGBA8, so
-        // clamp any bloom overshoot and let gamma2.2 handle the display
-        // encoding. No ACES: its ODT output matrix has negative terms
-        // that clamp dark pixels to pure zero.
-        //
-        // The hardcoded kMacosLdrExposure gain compensates for the tight
-        // RGBA8 dynamic range: scene values typically land in 0.02–0.1,
-        // which would gamma-encode to near-black without pre-scaling.
-        scene *= kMacosLdrExposure;
+        // LDR path (macOS default — RGBA8 scene FBO). uExposure now lands
+        // through correctly after the ShaderMgr cache-collision fix (#49)
+        // that used to hand out stale uniform locations after bloom / lens
+        // flare programs ran. The previous workaround (hardcoded 8× gain)
+        // over-exposed every textured planet to pure white (#25); now the
+        // caller's value drives the mapping and textured bodies retain
+        // their albedo.
+        scene *= uExposure;
         mapped = clamp(scene, 0.0, 1.0);
     }
 


### PR DESCRIPTION
## Summary

Phase 2 reported #25 as _"planet red channel missing — Earth black with phosphorescent green continents, ISS solar panels green"_ and hypothesised a broken texture decoder or shader swizzle. Investigation this session tells a different story:

1. The tonemap shader hardcoded an `8×` gain on the LDR path as a workaround for `uExposure` not reaching the shader on macOS. That root cause — **ShaderMgr uniform-location cache collision** — was fixed in [#49](https://github.com/kanik0/orbiter/pull/49); the hardcoded gain became both unnecessary and harmful.
2. With every pixel pre-multiplied by 8, any textured-planet albedo above ~0.125 clipped straight to `(255,255,255)`. The reddish Earth / greenish ISS solar panels in Phase-2 screenshots were **fully saturated output**, not a red-channel bug.
3. A debug-only frag-shader I left in the build tree from last session (force-red visualisation of the albedo) made the problem look worse than it was.

## Fix

- Remove `kMacosLdrExposure = 8.0`; let `uExposure` drive both HDR and LDR paths.
- Default `m_exposure = 1.0` (pass-through). Caller can still override via `SetExposure()` for HDR or user preference.

Two files, +16 / -28.

## Verified (capture-frame + interactive)

- **Demo/Saturn**: disc is tan-beige, rgb ≈ `(224, 217, 204)` — was `(255, 255, 255)`.
- **Demo/Dione**: icy-moon gray-white tones — was essentially black.
- **Demo/Today**: space is no longer washed blue; Earth day-side still renders with visible green continents on a black ocean. That appearance is _literal_ content of `EarthM.bmp`: a 256×128 palette BMP with only two entries used — index 0 → black, index 255 → pure green `(0,128,0)` land-mask — and D3D9 on Windows without an Earth texture pack renders the exact same pixels. Adding a real Earth texture pack is out of scope for a rendering-path fix.

ISS solar-panel green streak noted in Phase 2 is mesh PBR material, unrelated to the planet tonemap and not addressed here.

Fixes #25

## Test plan
- [x] \`Demo/Saturn\`, \`Demo/Dione\`, \`Demo/Today\` at \`--capture-frame=60/80\` produce natural-looking histograms (no pure-white saturation on textured planets)
- [x] Interactive smoke: Saturn tan, space dark
- [ ] Follow-up: Earth / Moon / Mars texture-pack integration — tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)