### PR TITLE
macos: fix XRSound silence (backslash paths + OpenAL source lifecycle)

### DIFF
--- a/Sound/XRSound/src/OpenALBackend.cpp
+++ b/Sound/XRSound/src/OpenALBackend.cpp
@@ -5,6 +5,23 @@
 
 #include "OpenALBackend.h"
 
+// Local path normaliser. XRPlatform.h pulls in Orbitersdk headers the
+// OpenAL backend target does not link against; a self-contained copy
+// keeps the decoders independent and does the same job.
+static inline const char *XRNormalizePathCopyLocal(const char *in, char *buf, size_t bufsz) {
+#ifdef _WIN32
+	(void)buf; (void)bufsz;
+	return in;
+#else
+	if (!in || !buf || bufsz == 0) return in;
+	size_t i = 0;
+	for (; i + 1 < bufsz && in[i]; ++i)
+		buf[i] = (in[i] == '\\') ? '/' : in[i];
+	buf[i] = 0;
+	return buf;
+#endif
+}
+
 // Decoders — declarations only. The implementation bodies live in
 // external/decoders_impl.cpp so we don't pay the inlining cost in
 // every TU that talks to the audio backend.
@@ -60,7 +77,13 @@ bool OpenALSound::isFinished()
 	if (!m_source) return true;
 	ALint state = 0;
 	alGetSourcei(m_source, AL_SOURCE_STATE, &state);
-	return state == AL_STOPPED || state == AL_INITIAL;
+	// AL_INITIAL means "source created, never played yet" — the XRSound
+	// lifecycle creates sources with startPaused=true and only lets
+	// UpdateSoundState's first setIsPaused(false) kick them off. Treating
+	// INITIAL as finished here caused UpdateSoundState to drop the source
+	// before it ever played, so nothing audible ever reached the device
+	// (#45). Only AL_STOPPED is a real "finished" state.
+	return state == AL_STOPPED;
 }
 
 void OpenALSound::setVolume(float volume)
@@ -79,8 +102,20 @@ void OpenALSound::setIsLooped(bool loop)
 void OpenALSound::setIsPaused(bool pause)
 {
 	if (!m_source) return;
-	if (pause) alSourcePause(m_source);
-	else       alSourcePlay(m_source);
+	// alSourcePlay on an already-playing source *rewinds it to the start*
+	// (per the OpenAL spec). XRSound drives setIsPaused(false) 20 times a
+	// second via UpdateSoundState, so issuing an unconditional alSourcePlay
+	// produced a stuttering "wha-wha-wha" loop that never advanced past the
+	// first sample (#45). Gate the call on the actual source state so we
+	// only issue Play for fresh / paused sources and only issue Pause for
+	// playing sources.
+	ALint state = 0;
+	alGetSourcei(m_source, AL_SOURCE_STATE, &state);
+	if (pause) {
+		if (state == AL_PLAYING) alSourcePause(m_source);
+	} else {
+		if (state != AL_PLAYING) alSourcePlay(m_source);
+	}
 }
 
 // Pan is simulated by positioning the source slightly off the listener's
@@ -289,6 +324,13 @@ bool OpenALEngine::ParseWav(const char *filename, std::vector<uint8_t> &data,
 ALuint OpenALEngine::LoadFile(const char *filename, float *outDurationSec)
 {
 	if (!m_initialized || !filename) return 0;
+
+	// Config-file values carry Windows-style backslashes; normalise so the
+	// decoders (dr_wav / dr_mp3 / stb_vorbis) and the buffer cache key all
+	// see the same POSIX-style path. Without this the decoders silently
+	// fail to open the file and nothing audible reaches the device (#45).
+	char pathBuf[1024];
+	filename = XRNormalizePathCopyLocal(filename, pathBuf, sizeof(pathBuf));
 
 	auto it = m_bufferCache.find(filename);
 	if (it != m_bufferCache.end()) {

--- a/Sound/XRSound/src/Utils/ConfigFileParser.cpp
+++ b/Sound/XRSound/src/Utils/ConfigFileParser.cpp
@@ -86,7 +86,13 @@ bool ConfigFileParser::ParseFile(const char *pFilename)
     sprintf(temp, "Parsing config file '%s'", pFilename);
     WriteLog(temp);
 
-    FILE *pFile = fopen(pFilename, "rt");
+    // Normalise Windows-style path separators before hitting fopen so the
+    // POSIX kernel can find "XRSound\XRSound.cfg" (shipped with backslashes
+    // in both the constant and the XRSound.cfg values) as "XRSound/...".
+    char pathBuf[1024];
+    const char *openPath = XRNormalizePathCopy(pFilename, pathBuf, sizeof(pathBuf));
+
+    FILE *pFile = fopen(openPath, "rt");
 
     if (pFile == nullptr)
     {

--- a/Sound/XRSound/src/Utils/ConfigFileParser.h
+++ b/Sound/XRSound/src/Utils/ConfigFileParser.h
@@ -16,6 +16,7 @@
 #include <stdio.h>
 
 #include "XRString.h"
+#include "../XRPlatform.h"   // for XRNormalizePathCopy
 #include <fstream>      // for ifstream
 
 const int MAX_LINE_LENGTH = 1024;
@@ -57,13 +58,18 @@ public:
 
     static void TrimString(char *pStr);
 
-    // Returns true if the supplied file exists and is readable
+    // Returns true if the supplied file exists and is readable. Input paths
+    // may contain Windows-style backslash separators (values lifted verbatim
+    // from XRSound vessel override .cfg files); normalise in a local buffer
+    // before touching std::ifstream so POSIX can resolve the path.
     static bool IsFileReadable(const char *pFilename)
     {
         if (!pFilename || !*pFilename)
             return false;
 
-        std::ifstream file(pFilename);
+        char buf[1024];
+        const char *path = XRNormalizePathCopy(pFilename, buf, sizeof(buf));
+        std::ifstream file(path);
         return file.good();
     }
 

--- a/Sound/XRSound/src/Utils/FileList.cpp
+++ b/Sound/XRSound/src/Utils/FileList.cpp
@@ -14,6 +14,13 @@
 FileList::FileList(const char *pRootPath, const bool bRecurseSubfolders) :
     m_rootPath(pRootPath), m_bRecurseSubfolders(bRecurseSubfolders), m_previousRandomFileIndex(-1)
 {
+    // Config-file values arrive with Windows-style separators (e.g.
+    // "XRSound\Default\Cabin Ambience"). std::filesystem on POSIX treats
+    // the backslash as a literal character, so DirectoryExists fails
+    // unless we rewrite the root path to use forward slashes.
+    LPTSTR buf = m_rootPath.GetBuffer(0);
+    XRNormalizePathInPlace(buf);
+    m_rootPath.ReleaseBuffer();
 }
 
 // Convenience constructor for when you only need to accept a single file type (e.g., "*.cfg")

--- a/Sound/XRSound/src/XRPlatform.h
+++ b/Sound/XRSound/src/XRPlatform.h
@@ -79,6 +79,32 @@ inline uint64_t GetTickCount64() {
 // trigger -Wredundant-decls and inline-redefinition errors. Nothing
 // further needed here.
 
+// Path-separator normalisation. XRSound ships its config file paths
+// with Windows-style backslashes ("XRSound\\Default\\Cabin Ambience"
+// etc.) and several source sites build paths with the same convention.
+// On POSIX those literal backslashes defeat `fopen` and
+// `std::filesystem` alike, so every path that flows into an I/O call
+// goes through this in-place normaliser first. No-op on Windows.
+inline void XRNormalizePathInPlace(char *path) {
+	if (!path) return;
+	for (char *p = path; *p; ++p)
+		if (*p == '\\') *p = '/';
+}
+inline const char *XRNormalizePathCopy(const char *in, char *buf, size_t bufsz) {
+	if (!in || !buf || bufsz == 0) return in;
+	size_t i = 0;
+	for (; i + 1 < bufsz && in[i]; ++i)
+		buf[i] = (in[i] == '\\') ? '/' : in[i];
+	buf[i] = 0;
+	return buf;
+}
+
 #endif // !_WIN32
+
+#ifdef _WIN32
+// No-op on Windows: paths are already backslash-native.
+inline void XRNormalizePathInPlace(char *) {}
+inline const char *XRNormalizePathCopy(const char *in, char *, size_t) { return in; }
+#endif
 
 #endif // __XRPLATFORM_H

--- a/Sound/XRSound/src/XRSoundConfigFileParser.cpp
+++ b/Sound/XRSound/src/XRSoundConfigFileParser.cpp
@@ -65,7 +65,11 @@ bool XRSoundConfigFileParser::ParseVesselSoundConfig(VESSEL *pVessel)
             csSanitizedClassName.SetAt(i, '_');   // replace invalid character
     }
 
+#ifdef _WIN32
     m_csOverrideFilename.Format("XRSound\\XRSound-%s.cfg", static_cast<const char *>(csSanitizedClassName));  // e.g., "XRSound\XRSound-XR2Ravenstar.cfg"
+#else
+    m_csOverrideFilename.Format("XRSound/XRSound-%s.cfg", static_cast<const char *>(csSanitizedClassName));
+#endif
     bOverrideFileExists = (PathFileExists(m_csOverrideFilename) != FALSE);
 
     if (bOverrideFileExists)

--- a/Sound/XRSound/src/XRSoundConfigFileParser.h
+++ b/Sound/XRSound/src/XRSoundConfigFileParser.h
@@ -15,7 +15,11 @@
 #include "XRSound.h"    // for PlaybackType
 #include <unordered_map>
 
+#ifdef _WIN32
 static const char *XRSOUND_CONFIG_FILE = "XRSound\\XRSound.cfg";
+#else
+static const char *XRSOUND_CONFIG_FILE = "XRSound/XRSound.cfg";
+#endif
 
 // XRSound.log always resides in the Orbiter root folder, alongside Orbiter.log and the XR vessel log files
 static const char *XRSOUND_LOG_FILE = "XRSound.log";


### PR DESCRIPTION
## Summary

Phase 2 reported #45 as _"XRSound initialises without crash but no audio events heard"_. Running the plugin interactively this session exposed **four stacked bugs**, none of which the \`xrsound_openal_smoke\` ctest exercised (it opens OpenAL and plays a synthetic buffer; every code path broken below sat outside it):

1. **Backslash path separators.** The global config constant (\`XRSOUND_CONFIG_FILE\`), the vessel override \`Format(\"XRSound\\\\XRSound-%s.cfg\", …)\` and every sound-file path inside XRSound*.cfg all ship with Windows-style \"\\\". \`fopen\`, \`std::ifstream\` and \`std::filesystem\` on POSIX take the backslash literally, so the global config, every vessel override and every per-sound \`IsFileReadable\` validation failed silently.
2. **\`OpenALSound::isFinished()\` reported \`AL_INITIAL\` as finished.** XRSound creates sources with \`startPaused=true\`; the first \`UpdateSoundState\` transitions them to \`AL_PLAYING\` via \`setIsPaused(false)\`. Treating \`AL_INITIAL\` as finished made \`UpdateSoundState\`'s \`release_sound:\` path drop the fresh source before it ever played.
3. **\`OpenALSound::setIsPaused(false)\` unconditionally called \`alSourcePlay\`.** XRSound drives \`setIsPaused(false)\` ~20 Hz per active sound. \`alSourcePlay\` on an already-playing source rewinds it to the start, which produced an audible stutter (_\"wha-wha-wha\"_) that never advanced past the first milliseconds — confirmed by the user in testing before the gate was added.

## Fix

- \`XRPlatform.h\`: self-contained \`XRNormalizePathInPlace\` / \`XRNormalizePathCopy\` helper (no-op on Windows).
- Four path choke points normalise just before I/O: two config-filename literals (gated by \`#ifdef _WIN32\`), \`ConfigFileParser::ParseFile\` before \`fopen\`, \`ConfigFileParser::IsFileReadable\`, and the \`FileList\` ctor's \`m_rootPath\`.
- Local copy of the normaliser in \`OpenALBackend.cpp\` so \`LoadFile\` and the buffer-cache key stay on forward-slash paths without pulling \`Orbitersdk.h\` into the backend target.
- \`OpenALSound::isFinished()\`: only \`AL_STOPPED\` counts as finished.
- \`OpenALSound::setIsPaused()\`: query \`AL_SOURCE_STATE\` and only issue \`alSourcePlay\` when the source is \`AL_INITIAL\`/\`AL_PAUSED\`/\`AL_STOPPED\` (not already playing).

7 files, +101 / -6.

## Verified interactively — Demo/Atlantis Ascent AP

- Cabin Ambience loops continuously
- \"Welcome aboard, all systems nominal\" radio message plays once in full
- SRB ignition + main engines audible at launch
- Atlantis / ShuttleA / DG override configs parse without errors

## Test plan
- [x] \`XRSound.cfg\` parses on POSIX (no \"fopen failed\" errors)
- [x] Vessel override configs (XRSound-Atlantis.cfg, XRSound-ShuttleA.cfg) parse without per-line errors
- [x] \`OpenALSound::isFinished()\` only returns true for AL_STOPPED
- [x] \`setIsPaused(false)\` is idempotent on already-playing sources (interactive: no stutter)
- [ ] \`xrsound_openal_smoke\` ctest still passes — next run should cover
- [ ] Cross-scenario audio smoke: Docked at ISS (docking clanger), DG ISS Approach (engine + RCS)

**Note on build config.** XRSound is gated behind \`ORBITER_BUILD_XRSOUND\` (default \`ON\` per \`CMakeLists.txt\`). My cache had it \`OFF\`; reconfigured with \`-DORBITER_BUILD_XRSOUND=ON\` before this work was possible. No code change needed — just a reminder for anyone whose cache inherited the old default.

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)