### PR TITLE
macos: fix Alt+F1 help shortcut; resolve Ctrl+F1/F2 triage

### DIFF
--- a/Html/CMakeLists.txt
+++ b/Html/CMakeLists.txt
@@ -3,3 +3,36 @@ add_subdirectory(Scenarios)
 if(ORBITER_MAKE_DOC)
 	add_subdirectory(Main)
 endif()
+
+# Non-Windows builds don't have the HTML Help Compiler (HHC) needed to roll
+# Html/Main into orbiter.chm; add_subdirectory(Main) above is skipped unless
+# ORBITER_MAKE_DOC is on, and even then it only produces the .chm.
+# For the POSIX help viewer (DlgHelp::OpenHelp hands the topic to `open` /
+# `xdg-open` — see Src/Orbiter/DlgHelp.cpp:OpenInBrowser) we need the raw
+# .htm / .css / media alongside the binary so the browser can resolve
+# relative URLs. Mirror the source tree to the build output's Html/Main
+# on every configure, no CHM involvement.
+if(NOT WIN32)
+	file(GLOB_RECURSE HTML_MAIN_FILES
+		RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/Main
+		Main/*.htm Main/*.html Main/*.css Main/*.js
+		Main/*.jpg Main/*.jpeg Main/*.png Main/*.gif
+		Main/*.hhc Main/*.hhk Main/*.hhp)
+	set(HTML_MAIN_STAMPS)
+	foreach(rel IN LISTS HTML_MAIN_FILES)
+		set(src ${CMAKE_CURRENT_SOURCE_DIR}/Main/${rel})
+		set(dst ${ORBITER_BINARY_HTML_DIR}/Main/${rel})
+		add_custom_command(OUTPUT ${dst}
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different ${src} ${dst}
+			DEPENDS ${src})
+		list(APPEND HTML_MAIN_STAMPS ${dst})
+	endforeach()
+	add_custom_target(orbiter_html_main ALL DEPENDS ${HTML_MAIN_STAMPS})
+	install(DIRECTORY Main/
+		DESTINATION ${ORBITER_INSTALL_HTML_DIR}/Main
+		FILES_MATCHING
+			PATTERN "*.htm" PATTERN "*.html" PATTERN "*.css" PATTERN "*.js"
+			PATTERN "*.jpg" PATTERN "*.jpeg" PATTERN "*.png" PATTERN "*.gif"
+			PATTERN "*.hhc" PATTERN "*.hhk" PATTERN "*.hhp"
+			PATTERN "CMakeLists.txt" EXCLUDE)
+endif()

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -2892,7 +2892,18 @@ void Orbiter::KbdInputBuffered_System (char *kstate, DIDEVICEOBJECTDATA *dod, DW
 			CFG_UIPRM &prm = g_pOrbiter->Cfg()->CfgUIPrm;
 			prm.MenuMode = prm.MenuMode == 0 ? 2:0;
 		}
-		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgHelp))              pDlgMgr->EnsureEntry<DlgHelp>();
+		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgHelp)) {
+#ifdef _WIN32
+			pDlgMgr->EnsureEntry<DlgHelp>();
+#else
+			// DlgHelp::Display()/OnDraw() are intentionally no-ops on POSIX
+			// (the help viewer is the platform browser, not an ImGui window).
+			// Bypass the empty dialog and launch the manual index directly
+			// via the cross-platform "open" / "xdg-open" fallback (#43).
+			HELPCONTEXT hc = {(char*)"html/orbiter.chm", (char*)"/intro.htm", nullptr, nullptr};
+			DlgHelp tmp; tmp.OpenHelp(&hc);
+#endif
+		}
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgCamera))            pDlgMgr->EnsureEntry<DlgCamera>();
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgSimspeed))          pDlgMgr->EnsureEntry<DlgTacc>();
 		else if (keymap.IsLogicalKey(key, kstate, OAPI_LKEY_DlgCustomCmd))         pDlgMgr->EnsureEntry<DlgFunction>();


### PR DESCRIPTION
## Summary

Batch triage of three keyboard-shortcut issues filed during Phase 2. Interactive testing on Darwin 25.4.0 showed only one of the three is an actual code bug in the current tree — the other two were already handled or obsoleted by earlier PRs.

### #41 Ctrl+F1 DlgCamera — no code change, close as macOS OS conflict

Ctrl+F1 is a macOS system-wide shortcut ("Toggle Full Keyboard Access", System Settings → Keyboard → Keyboard Shortcuts). The event is captured by the OS before SDL ever sees it, so Orbiter's dispatch never fires. Instrumented the buffered-key path to confirm: with "Full Keyboard Access" enabled, Ctrl+F1 produces no entry in the dispatch log.

**Cmd+F1 works already** and opens DlgCamera via the existing keymap: `SDLPlatform.cpp:91` maps `SDL_SCANCODE_LGUI` to DInput slot `0x1D` (LCTRL), so the `OAPI_KEY_F1 | KMOD_CTRL → DlgCamera` binding matches both Ctrl+F1 and Cmd+F1 at the Orbiter layer. Users whose macOS shortcut is disabled also get Ctrl+F1 natively.

### #42 Ctrl+F2 DlgTacc frozen — no longer reproducible

Interactive test: the dialog opens, 1×/10×/100×/1000× buttons change warp, slider snaps, X-button and re-pressing Ctrl+F2 both dismiss. The original "frozen" reading was almost certainly a side-effect of the ShaderMgr uniform-cache collision ([#49](https://github.com/kanik0/orbiter/pull/49)) leaking bad state into the ImGui render; with the cache keyed correctly the dialog is interactive.

### #43 Alt+F1 DlgHelp — real bug, fixed here

Dispatch reached `pDlgMgr->EnsureEntry<DlgHelp>()` correctly (confirmed with temporary instrumentation), but `DlgHelp::Display()` and `DlgHelp::OnDraw()` are both `{}` — the help viewer is the CHM control on Windows and the OS browser on POSIX, not an ImGui panel. On macOS the empty dialog rendered nothing, so the user saw silence.

**Fix**:
- `Src/Orbiter/Orbiter.cpp`: on POSIX, bypass the empty-dialog route and call `DlgHelp::OpenHelp()` directly with the manual index topic (`html/orbiter.chm` / `/intro.htm`), which hands the absolute path to the OS opener via `DlgHelp::OpenInBrowser`. Windows path unchanged.
- `Html/CMakeLists.txt`: mirror the raw `Html/Main/` tree into `${ORBITER_BINARY_HTML_DIR}/Main/` on non-Windows builds (the CHM compilation behind `ORBITER_MAKE_DOC` is Windows-only and doesn't help the POSIX browser). Adds an `install` rule for the same files in release builds. No effect on Windows.

2 files, +45 / -1.

## Verified interactively

- **Alt+F1**: default browser opens on `Html/Main/intro.htm` ✓
- **Cmd+F1**: DlgCamera opens ✓
- **Cmd+F2**: DlgTacc opens, buttons and slider work, dismissal works ✓
- **Ctrl+M**: DlgMap still works ✓

## Test plan
- [x] Alt+F1 fires browser on macOS
- [x] Cmd+F1/F2 still dispatch as intended (no regression)
- [x] DlgTacc interactive (buttons, slider, dismissal)
- [ ] Ctrl+F1 on a macOS box with "Full Keyboard Access" disabled — expected to work natively; untested this session

Fixes #41
Fixes #42
Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)