### PR TITLE
macos: fix Atlantis F8 panel-mode SIGSEGV (partial for #54)

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -1136,7 +1136,10 @@ oapi::Sketchpad *OGLClient::clbkGetSketchpad(SURFHANDLE surf) {
 	if (!surf) return nullptr;
 	if (!m_imguiInitialized) return nullptr;
 	if (!ImGui::GetCurrentContext()) return nullptr;
-	if (!ImGui::GetIO().Fonts || !ImGui::GetIO().Fonts->IsBuilt()) return nullptr;
+	// Don't gate on IsBuilt(): the dynamic atlas flips it to false transiently
+	// while baking new glyphs. Text() handles not-ready atlas; non-text ops
+	// don't need it.
+	if (!ImGui::GetIO().Fonts) return nullptr;
 	// Target surface must be an FBO-backed render target; texture-only
 	// surfaces can't accept draw commands. Returning nullptr here matches
 	// the oapi contract: callers must handle the missing sketchpad.

--- a/Src/Vessel/Atlantis/Atlantis/Atlantis.cpp
+++ b/Src/Vessel/Atlantis/Atlantis/Atlantis.cpp
@@ -1369,6 +1369,7 @@ void Atlantis::RedrawPanel_MFDButton (SURFHANDLE surf, int mfd)
 	using namespace oapi;
 
 	Sketchpad *pSkp = oapiGetSketchpad(surf);
+	if (!pSkp) return;   // macOS: oapiGetSketchpad may legitimately return NULL
 
 	// D. Beachy: BUGFIX: if MFD powered off, cover separator lines and do not paint buttons
     if (oapiGetMFDMode(mfd) == MFD_NONE) {


### PR DESCRIPTION
## Summary

Fixes the SIGSEGV that happened every time the user pressed F8 in Atlantis scenarios on macOS. **This does not fully resolve [#54](https://github.com/kanik0/orbiter/issues/54)** — the diagonal/skewed cockpit rendering is still present. That issue remains open and will be investigated in a follow-up PR.

Two combined bugs broke Atlantis cockpit-mode switching on macOS:

1. **`OGLClient::clbkGetSketchpad` over-strict gate** — `!ImGui::GetIO().Fonts->IsBuilt()` rejected every sketchpad request whenever the dynamic font atlas was transiently rebuilding. `OGLSketchpad::Text()` already no-ops when the atlas isn't ready, and non-text ops don't use it, so the gate was silently dropping valid work.
2. **`Atlantis::RedrawPanel_MFDButton` missing null check** — the vessel dereferenced the Sketchpad pointer unconditionally. On Windows (DX7 GDI) `oapiGetSketchpad` never returns NULL for a valid surface, but on macOS it legitimately can. Bug #1 made the pointer NULL and the deref SIGSEGV'd inside the VC redraw dispatch.

Stack trace of the original crash (signal 11):
```
Atlantis::RedrawPanel_MFDButton + 44
Atlantis::clbkVCRedrawEvent + 88
Vessel::VCRedrawEvent + 148
VirtualCockpit::RedrawArea + 108
Pane::TriggerVCRedrawArea + 124
oapiVCTriggerRedrawArea + 44
Atlantis::clbkMFDMode + 44
Vessel::MFDchanged + 124
Pane::OpenMFD + 1428
Pane::SetPanelMode + 1652
Pane::TogglePanelMode + 104
```

## Test plan

- [x] Build `out/build/macos-arm64-debug` with ORBITER_BUILD_XRSOUND=ON
- [x] `./Orbiter` → Demo/Atlantis Ascent AP → Launch: VC renders, MFDs populated
- [x] Press F8 repeatedly: camera mode cycles without crash (VC ↔ Generic)
- [x] Orbit MFD contents (SMi/PeR/ApR/etc.) legible on the VC quad
- [ ] No regression in other scenarios that draw HUDs via Sketchpad (Surface HUD, DG, ShuttleA)
- [ ] Regression check on Windows build (sketchpad path unchanged for DX7, null check is no-op)

Related to #54 (does not close it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)