### PR TITLE
macos: fix FBO-incomplete log spam + exit-time SIGSEGV

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -1136,7 +1136,10 @@ oapi::Sketchpad *OGLClient::clbkGetSketchpad(SURFHANDLE surf) {
 	if (!surf) return nullptr;
 	if (!m_imguiInitialized) return nullptr;
 	if (!ImGui::GetCurrentContext()) return nullptr;
-	if (!ImGui::GetIO().Fonts || !ImGui::GetIO().Fonts->IsBuilt()) return nullptr;
+	// Don't gate on IsBuilt(): the dynamic atlas flips it to false transiently
+	// while baking new glyphs. Text() handles not-ready atlas; non-text ops
+	// don't need it.
+	if (!ImGui::GetIO().Fonts) return nullptr;
 	// Target surface must be an FBO-backed render target; texture-only
 	// surfaces can't accept draw commands. Returning nullptr here matches
 	// the oapi contract: callers must handle the missing sketchpad.

--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -978,7 +978,13 @@ SURFHANDLE OGLClient::clbkLoadSurface(const char *fname, DWORD attrib, bool bPat
 	SURFHANDLE h = clbkLoadTexture(fname, 0);
 	if (h && attrib) {
 		OGLSurface *s = (OGLSurface*)h;
-		// If render target requested, ensure FBO is created
+		// WrapTexture() set m_attrib to OAPISURFACE_TEXTURE. Merge the
+		// caller's requested attribs so EnsureFBO() attaches the depth
+		// renderbuffer (required for RT/SKETCHPAD use). A previously-
+		// wrapped file-loaded GL texture may still not be color-renderable
+		// on macOS GL 4.1 — EnsureFBO() will log once and fail silently
+		// if so; clbkGetSketchpad() then rejects further attempts.
+		s->AddAttrib(attrib);
 		if (attrib & (OAPISURFACE_RENDERTARGET | OAPISURFACE_SKETCHPAD))
 			s->EnsureFBO();
 	}
@@ -1140,10 +1146,14 @@ oapi::Sketchpad *OGLClient::clbkGetSketchpad(SURFHANDLE surf) {
 	// while baking new glyphs. Text() handles not-ready atlas; non-text ops
 	// don't need it.
 	if (!ImGui::GetIO().Fonts) return nullptr;
-	// Target surface must be an FBO-backed render target; texture-only
-	// surfaces can't accept draw commands. Returning nullptr here matches
-	// the oapi contract: callers must handle the missing sketchpad.
+	// Target surface must be render-target capable. Pure-texture surfaces
+	// (OAPISURFACE_TEXTURE without any RT bit, typically loaded via
+	// clbkLoadTexture) can't accept draw commands — attempting EnsureFBO on
+	// a WrapTexture-wrapped GL texture fails with MISSING_ATTACHMENT and
+	// floods stderr. Reject them up-front; callers must handle the nullptr.
 	OGLSurface *s = (OGLSurface*)surf;
+	const DWORD rtMask = OAPISURFACE_RENDERTARGET | OAPISURFACE_RENDER3D | OAPISURFACE_SKETCHPAD;
+	if (!(s->GetAttrib() & rtMask)) return nullptr;
 	if (!s->EnsureFBO()) return nullptr;
 	OGLSketchpad::InitShared(m_shaderMgr);
 	return new OGLSketchpad(surf, m_shaderMgr);

--- a/OVP/OGLClient/OGLSurface.cpp
+++ b/OVP/OGLClient/OGLSurface.cpp
@@ -43,7 +43,7 @@ OGLSurface::OGLSurface()
 	  m_msaaColorRbo(0), m_msaaDepthRbo(0), m_depthRbo(0),
 	  m_width(0), m_height(0), m_attrib(0),
 	  m_refCount(1), m_samples(0), m_hasStencil(false),
-	  m_ownsTexture(false),
+	  m_ownsTexture(false), m_fboFailed(false),
 	  m_colorKey(0), m_hasColorKey(false),
 	  m_prevDrawFBO(0), m_prevReadFBO(0)
 {
@@ -140,6 +140,7 @@ GLuint OGLSurface::EnsureFBO()
 {
 	if (m_fbo) return m_fbo;
 	if (!m_texId) return 0;
+	if (m_fboFailed) return 0;
 
 	// --- Single-sample resolve FBO (always built). ---------------------------
 	glGenFramebuffers(1, &m_fbo);
@@ -160,11 +161,12 @@ GLuint OGLSurface::EnsureFBO()
 
 	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 	if (status != GL_FRAMEBUFFER_COMPLETE) {
-		fprintf(stderr, "[OGLSurface] Resolve FBO incomplete: 0x%x (tex=%u, %ux%u, stencil=%d)\n",
-		        status, m_texId, m_width, m_height, (int)m_hasStencil);
+		fprintf(stderr, "[OGLSurface] Resolve FBO incomplete: 0x%x (tex=%u, %ux%u, attrib=0x%lx, stencil=%d)\n",
+		        status, m_texId, m_width, m_height, (unsigned long)m_attrib, (int)m_hasStencil);
 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
 		glDeleteFramebuffers(1, &m_fbo);
 		m_fbo = 0;
+		m_fboFailed = true;  // don't retry every BindFBO call
 		return 0;
 	}
 

--- a/OVP/OGLClient/OGLSurface.h
+++ b/OVP/OGLClient/OGLSurface.h
@@ -56,6 +56,10 @@ public:
 	DWORD  GetWidth() const { return m_width; }
 	DWORD  GetHeight() const { return m_height; }
 	DWORD  GetAttrib() const { return m_attrib; }
+	// Merge additional attribute flags into m_attrib. Used by clbkLoadSurface
+	// to promote a file-loaded (wrapped) texture to render-target usage so
+	// EnsureFBO() attaches the depth renderbuffer required by the FBO.
+	void   AddAttrib(DWORD extra) { m_attrib |= extra; }
 	bool   IsRenderTarget() const { return m_fbo != 0 || m_msaaFbo != 0; }
 	int    GetSamples() const { return m_samples; }
 	bool   HasStencil() const { return m_hasStencil; }
@@ -109,6 +113,7 @@ private:
 	int   m_samples;
 	bool  m_hasStencil;
 	bool  m_ownsTexture;
+	bool  m_fboFailed;      // set when EnsureFBO() has failed once; skip retries
 
 	DWORD m_colorKey;
 	bool  m_hasColorKey;

--- a/OVP/OGLClient/OGLTexture.cpp
+++ b/OVP/OGLClient/OGLTexture.cpp
@@ -289,7 +289,9 @@ OGLTexture *OGLTexture::LoadBMP(const char *path) {
 	GLuint tex = 0;
 	glGenTextures(1, &tex);
 	glBindTexture(GL_TEXTURE_2D, tex);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba.data());
+	// Use sized internal format so the resulting texture is color-renderable;
+	// macOS GL 4.1-via-Metal rejects unsized GL_RGBA as an FBO color attachment.
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, rgba.data());
 	glGenerateMipmap(GL_TEXTURE_2D);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -375,7 +375,12 @@ int main (int argc, char *argv[])
 
 	g_pOrbiter->Run ();
 	delete g_pOrbiter;
-	return 0;
+	// On macOS dyld4 RTLD_LOCAL dlclose() is often a no-op, so runtime-loaded
+	// plugins stay mapped until exit() fires __cxa_finalize_ranges. Some of
+	// their global destructors reference state ~Orbiter already tore down,
+	// which SIGSEGVs inside __cxa_finalize_ranges. Skip C++ destructors
+	// altogether — the process is dying anyway and the OS reclaims resources.
+	_exit(0);
 }
 #endif // _WIN32
 

--- a/Src/Vessel/Atlantis/Atlantis/Atlantis.cpp
+++ b/Src/Vessel/Atlantis/Atlantis/Atlantis.cpp
@@ -1369,6 +1369,7 @@ void Atlantis::RedrawPanel_MFDButton (SURFHANDLE surf, int mfd)
 	using namespace oapi;
 
 	Sketchpad *pSkp = oapiGetSketchpad(surf);
+	if (!pSkp) return;   // macOS: oapiGetSketchpad may legitimately return NULL
 
 	// D. Beachy: BUGFIX: if MFD powered off, cover separator lines and do not paint buttons
     if (oapiGetMFDMode(mfd) == MFD_NONE) {


### PR DESCRIPTION
## Summary

Two macOS stability issues surfaced while investigating #54 (the Atlantis F8 crash addressed in #55). Both are independent of the Atlantis vessel and affect any macOS session.

> **Depends on [#55](https://github.com/kanik0/orbiter/pull/55)** — rebase/merge after that lands so the diff collapses to just the changes here.

### 1. `[OGLSurface] Resolve FBO incomplete: 0x8cd6` log spam (20× per session)

Three root causes stacked:

- **`OGLTexture::LoadBMP` used unsized `GL_RGBA`** for the internal format. macOS GL 4.1-via-Metal requires a sized color-renderable format (`GL_RGBA8`) for FBO color attachments; the unsized one is silently accepted at texture creation but rejected with `GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT` when the texture is later attached as an FBO color target.
- **`clbkLoadSurface(fname, attrib)` didn't propagate the requested RT/SKETCHPAD bits** into the wrapped surface's `m_attrib`. Without the RT bit, `EnsureFBO()` skips the depth renderbuffer, and on macOS that combined with the unsized color format produced the MISSING_ATTACHMENT error.
- **`EnsureFBO()` had no fail-once cache** — every subsequent `BindFBO()` retried the failed attach and re-logged. With Atlantis VC redraws that's 20+ repeats per session.

**Fixes:**

- `OGLSurface::AddAttrib(DWORD)` accessor so `clbkLoadSurface` can merge caller-requested RT attribs onto a wrapped texture before `EnsureFBO()`.
- `OGLTexture::LoadBMP` uses sized `GL_RGBA8`.
- `OGLSurface::m_fboFailed` remembers a failed `EnsureFBO()` attempt so later `BindFBO()` calls are silent no-ops.
- `clbkGetSketchpad` now rejects pure-texture surfaces (no RT bit) up-front instead of attempting a futile FBO attach.

### 2. SIGSEGV during normal exit

Stack trace:
```
0 crashHandler + 52
1 _sigtramp + 56
2 ??? (0x...)
3 libsystem_c __cxa_finalize_ranges + 416
4 libsystem_c exit + 44
5 dyld start + 7040
```

Root cause: macOS dyld4 treats `dlclose()` on `RTLD_LOCAL` dylibs as best-effort. Plugins loaded at runtime stay mapped after `~Orbiter` explicitly unloads them, and their C++ global destructors run at `exit()` time against state the main app already tore down, landing in an unmapped code page (`???` frame).

**Fix:** replace `return 0` with `_exit(0)` at the end of `main()` on POSIX. Same pattern as the existing `crashHandler`; skips C++ destructors, but the process is dying and the OS reclaims resources.

## Test plan

- [x] Build `out/build/macos-arm64-debug` with `ORBITER_BUILD_XRSOUND=ON`
- [x] `./Orbiter` → Demo/Atlantis Ascent AP → Launch → F8×2 → Cmd+Q
  - Before: 20 \`Resolve FBO incomplete\` lines + \`=== CRASH: signal 11 ===\` on exit
  - After: 1 FBO warning (unrelated blit target case, single log per session thanks to fail-once cache) + clean exit, plugins unload sequentially
- [ ] No regression in scenarios that do heavy Sketchpad work on plain RT surfaces (DG HUD, ShuttleA panels)
- [ ] Windows build unaffected (BMP path change is sized-format upgrade, `_exit(0)` inside `#else !_WIN32`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)