### PR TITLE
macos: fix tilted generic cockpit — 2D panel mat3 shear

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -677,11 +677,19 @@ void OGLClient::clbkRender2DPanel(SURFHANDLE *hSurf, MESHHANDLE hMesh, MATRIX3 *
 	else
 		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-	// Upload transform as mat3 uniform
+	// Upload transform as a column-major mat3 with only the diagonal scale
+	// (m11, m22) and translation column (m13, m23) — matching the D3D9
+	// client (D3D9Client.cpp:1948) which reads only those four elements.
+	// DefaultPanel builds `transf = {1,-0.5,0, 0,1,-0.5, 0,0,1}`: the -0.5
+	// in m12/m23 positions is ignored on Windows but, applied as a full
+	// mat3, would shear the generic cockpit (the tilted rendering tracked
+	// in #54). Zeroing the off-diagonal shear reproduces Win32 behaviour.
+	// Layout: shader computes `uTransform * vec3(x, y, 1)`, so we need
+	// columns (m11, 0, 0), (0, m22, 0), (m13, m23, 1).
 	float mat[9] = {
-		(float)T->m11, (float)T->m12, (float)T->m13,
-		(float)T->m21, (float)T->m22, (float)T->m23,
-		(float)T->m31, (float)T->m32, (float)T->m33
+		(float)T->m11, 0.0f,          0.0f,
+		0.0f,          (float)T->m22, 0.0f,
+		(float)T->m13, (float)T->m23, 1.0f
 	};
 	glUniformMatrix3fv(m_shaderMgr->GetUniformLoc(m_panel2dShader, "uTransform"), 1, GL_FALSE, mat);
 	glUniform2f(m_shaderMgr->GetUniformLoc(m_panel2dShader, "uViewport"), (float)m_viewW, (float)m_viewH);


### PR DESCRIPTION
## Summary

Fixes [#54](https://github.com/kanik0/orbiter/issues/54) — the tilted/skewed generic cockpit rendering on macOS. The glass-cockpit panel (HUD + MFD overlays + engine/RCS blocks that Orbiter draws when no 2D panel is registered) rendered with a visible shear: the right side of every panel slumped ~0.5 pixels per horizontal pixel, tilting MFDs, buttons and HUD ladders into diagonals. The effect showed up on **every vessel** that uses the generic cockpit — Atlantis and DeltaGlider were the most obvious cases.

## Root cause

`OGLClient::clbkRender2DPanel` uploaded the caller's `MATRIX3 T` argument as a full column-major `mat3` uniform, so the shader applied **every** element:

```glsl
vec3 transformed = uTransform * vec3(aPos, 1.0);
```

`DefaultPanel::Render` (`Src/Orbiter/Defpanel.cpp:433`) builds:

```cpp
static MATRIX3 transf = {1,-0.5,0, 0,1,-0.5, 0,0,1};
```

The `-0.5` in `m12` is **discarded on Windows** — `D3D9Client::clbkRender2DPanel` reads only `m11, m13, m22, m23` (diagonal scale + translation column) and ignores the off-diagonals:

```cpp
// D3D9Client.cpp:1948
float sx = 1.0f/(float)(T->m11),  dx = (float)(T->m13);
float sy = 1.0f/(float)(T->m22),  dy = (float)(T->m23);
```

On macOS the shear leaked through, producing `y' = y - 0.5·x` — the exact tilt users saw.

## Investigation

Before finding the fix I instrumented the vessel render pipeline to dump `vrot`, `cRot`, `cRot^T · vrot`, and the final VP matrix every 120 frames. The 3D pipeline was clean:

```
[DBG54] cRot^T*vrot=[+1.000 -0.000 +0.000 / -0.000 +1.000 +0.000 / +0.000 +0.000 +1.000]
[DBG54] VP_col_major=[+0.94 +0.73 +0.28 +0.28 | -0.22 +1.38 -0.57 -0.57 | -0.49 +0.75 +0.78 +0.78 | +0.00 +0.00 -2.00 +0.00]
```

`cRot^T · vrot = I` confirmed the camera-frame cancels the vessel rotation exactly in VC — so the skew wasn't a 3D model/view bug. The diagnostic also revealed `cockpitMode=1` (`COCKPIT_GENERIC`), not `COCKPIT_VIRTUAL` — which meant the \"VC skew\" reports were actually about the generic-cockpit 2D overlay. That narrowed the search to `clbkRender2DPanel`, and comparing against D3D9 immediately surfaced the off-diagonal discrepancy.

## Fix

Upload only the four honoured elements as a column-major `mat3`, zeroing the shear and perspective rows. Shader and calling code are unchanged.

```cpp
float mat[9] = {
    (float)T->m11, 0.0f,          0.0f,
    0.0f,          (float)T->m22, 0.0f,
    (float)T->m13, (float)T->m23, 1.0f
};
```

## Test plan

- [x] Build `out/build/macos-arm64-debug` clean
- [x] `./Orbiter` → `Demo/Virtual cockpit.scn` → Launch: MFDs/buttons/HUD ladder are axis-aligned, matching the Windows reference screenshot
- [x] Same for `Demo/Atlantis Ascent AP`
- [ ] No regression for vessels that register a proper 2D panel (DG F8 → 2D panel)
- [ ] Windows build unaffected (this file is macOS-only)

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)