### PR TITLE
macos: fix MFD trails, tape Y-flip, transparent background + side buttons

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -528,11 +528,25 @@ void OGLClient::BlitQuad(OGLSurface *tgt, DWORD tgtx, DWORD tgty, DWORD tgtw, DW
 	float x1 = (float)(tgtx + tgtw) / tw * 2.0f - 1.0f;
 	float y1 = 1.0f - (float)tgty / th * 2.0f;
 
+	// UV orientation depends on whether the source has been *rendered into*
+	// (FBO-backed render target, e.g., sketchpad MFD surface) or was uploaded
+	// from an image file. FBO-rendered content stores its visual top at OGL
+	// texture v=1; file-loaded textures store their visual top at v=0. The
+	// blit must pair "NDC top of dst" with the source's visual-top v so the
+	// rendered output keeps the same orientation as the input. Without this
+	// split, chained FBO→FBO→FBO blits (MFD tapes1→surf→tex, #58) picked up
+	// an extra Y-flip per hop and the tape/horizon labels came out mirrored.
+	const DWORD rtMask = OAPISURFACE_RENDERTARGET | OAPISURFACE_SKETCHPAD |
+	                     OAPISURFACE_GDI | OAPISURFACE_RENDER3D;
+	const bool srcIsRT = (src->GetAttrib() & rtMask) != 0;
+	const float vTop = srcIsRT ? v1 : v0;
+	const float vBot = srcIsRT ? v0 : v1;
+
 	float verts[] = {
-		x0, y0, u0, v1,
-		x1, y0, u1, v1,
-		x0, y1, u0, v0,
-		x1, y1, u1, v0,
+		x0, y0, u0, vBot,
+		x1, y0, u1, vBot,
+		x0, y1, u0, vTop,
+		x1, y1, u1, vTop,
 	};
 
 	// Bind target. For a surface target use BindFBO() (which also handles MSAA
@@ -570,14 +584,19 @@ void OGLClient::BlitQuad(OGLSurface *tgt, DWORD tgtx, DWORD tgty, DWORD tgtw, DW
 		glUniform3f(m_shaderMgr->GetUniformLoc(m_blitShader, "uColorKey"), ckr, ckg, ckb);
 	}
 
-	glEnable(GL_BLEND);
-	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+	// DX7 IDirectDrawSurface::Blt is a raw pixel copy (with optional colorkey
+	// discard), not an alpha blend. Leaving GL_BLEND on here made every blt
+	// composite src over dst, so MFD surface→texture copies (Mfd.cpp:812,
+	// after Fill(0x000000) which clears to alpha=0) retained the previous
+	// frame's content at every cleared pixel — the trail artifacts in #58.
+	// Disable blending; the frag shader's `discard` already handles the
+	// colorkey path.
+	glDisable(GL_BLEND);
 	glDisable(GL_DEPTH_TEST);
 	glViewport(0, 0, tgt->GetWidth(), tgt->GetHeight());
 
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 
-	glDisable(GL_BLEND);
 	glEnable(GL_DEPTH_TEST);
 	glBindVertexArray(0);
 	glUseProgram(0);
@@ -723,6 +742,17 @@ void OGLClient::clbkRender2DPanel(SURFHANDLE *hSurf, MESHHANDLE hMesh, MATRIX3 *
 			hTex = oapiGetTextureHandle(hMesh, texIdx + 1);
 		}
 
+		// MFD textures are painted by sketchpad into an FBO, which stores the
+		// visual top at OGL v=1. The defpanel mesh's tv values assume D3D's
+		// "v=0 at top" convention, so we flip tv for MFD groups to keep the
+		// Surface MFD tape/horizon labels upright (#58). We *only* flip for
+		// MFD slots: the HUD font atlas (hudTex) is loaded with
+		// OAPISURFACE_RENDERTARGET too — but its content is a BMP, not an
+		// FBO render — so attrib-based detection would wrongly flip the
+		// HUD pitch-ladder glyphs (they came out as "ORBIT" labels because
+		// the font atlas was being sampled vertically inverted).
+		const bool isMFD = (texIdx >= TEXIDX_MFD0 && texIdx < TEXIDX_MFD0 + MAXMFD);
+		const bool flipV = isMFD;
 		if (hTex) {
 			OGLSurface *texSurf = (OGLSurface*)hTex;
 			glActiveTexture(GL_TEXTURE0);
@@ -744,7 +774,7 @@ void OGLClient::clbkRender2DPanel(SURFHANDLE *hSurf, MESHHANDLE hMesh, MATRIX3 *
 			vdata[i * 4 + 0] = grp->Vtx[i].x;
 			vdata[i * 4 + 1] = grp->Vtx[i].y;
 			vdata[i * 4 + 2] = grp->Vtx[i].tu;
-			vdata[i * 4 + 3] = grp->Vtx[i].tv;
+			vdata[i * 4 + 3] = flipV ? (1.0f - grp->Vtx[i].tv) : grp->Vtx[i].tv;
 		}
 		glBindBuffer(GL_ARRAY_BUFFER, tmpVBO);
 		glBufferData(GL_ARRAY_BUFFER, vdata.size() * sizeof(float), vdata.data(), GL_STREAM_DRAW);

--- a/OVP/OGLClient/OGLSurface.cpp
+++ b/OVP/OGLClient/OGLSurface.cpp
@@ -249,13 +249,27 @@ void OGLSurface::UnbindFBO()
 	m_prevDrawFBO = m_prevReadFBO = 0;
 }
 
+// DX7 IDirectDrawSurface::Fill treats `col` as a packed RGB value (surfaces
+// were typically RGB with no alpha channel). Callers like
+// Instrument::ClearSurface (Mfd.cpp:735) and Instrument_Surface::UpdateHorizon
+// pass 0x000000 / 0xRRGGBB and expect opaque output. Taking alpha from
+// (col>>24) would give alpha=0 for those cases — fine on DX7, but on OGL it
+// leaves the cleared pixels transparent, so MFDs show the 3D scene through
+// (and the Surface MFD attitude ball loses its sky/ground fill — #58). Treat
+// alpha=0 inputs as "opaque"; honour an explicit non-zero alpha byte.
+static inline float AlphaFromCol(DWORD col)
+{
+	DWORD a = (col >> 24) & 0xFF;
+	return a ? (float)a / 255.0f : 1.0f;
+}
+
 void OGLSurface::Fill(DWORD col)
 {
 	BindFBO();
 	float r = ((col >> 16) & 0xFF) / 255.0f;
 	float g = ((col >>  8) & 0xFF) / 255.0f;
 	float b = ( col        & 0xFF) / 255.0f;
-	float a = ((col >> 24) & 0xFF) / 255.0f;
+	float a = AlphaFromCol(col);
 	glClearColor(r, g, b, a);
 	glClear(GL_COLOR_BUFFER_BIT);
 	UnbindFBO();
@@ -270,7 +284,7 @@ void OGLSurface::Fill(DWORD x, DWORD y, DWORD w, DWORD h, DWORD col)
 	float r = ((col >> 16) & 0xFF) / 255.0f;
 	float g = ((col >>  8) & 0xFF) / 255.0f;
 	float b = ( col        & 0xFF) / 255.0f;
-	float a = ((col >> 24) & 0xFF) / 255.0f;
+	float a = AlphaFromCol(col);
 	glClearColor(r, g, b, a);
 	glClear(GL_COLOR_BUFFER_BIT);
 	glDisable(GL_SCISSOR_TEST);

--- a/Orbitersdk/include/OrbiterPlatform.h
+++ b/Orbitersdk/include/OrbiterPlatform.h
@@ -241,7 +241,19 @@ inline HWND GetDesktopWindow() { return nullptr; }
 inline BOOL GetWindowRect(HWND, RECT*) { return FALSE; }
 inline BOOL GetClientRect(HWND, RECT*) { return FALSE; }
 inline int GetSystemMetrics(int) { return 0; }
-inline BOOL GetCursorPos(POINT* p) { if(p) { p->x = 0; p->y = 0; } return FALSE; }
+// Last known cursor position in drawable pixels (SDL window-local, scaled for
+// Retina). SDLPlatform::HandleMouse{Motion,Button} updates these; the pane's
+// per-frame hit-test (DefaultPanel::GetButtonState) queries GetCursorPos to
+// decide whether a held MFD function button should keep firing. Defined in
+// SDLPlatform.cpp.
+extern int g_posixCursorX;
+extern int g_posixCursorY;
+inline BOOL GetCursorPos(POINT* p) {
+	if (!p) return FALSE;
+	p->x = g_posixCursorX;
+	p->y = g_posixCursorY;
+	return TRUE;
+}
 inline BOOL SetCursorPos(int, int) { return FALSE; }
 inline BOOL ScreenToClient(HWND, POINT*) { return FALSE; }
 inline BOOL ClientToScreen(HWND, POINT*) { return FALSE; }

--- a/Src/Orbiter/SDLPlatform.cpp
+++ b/Src/Orbiter/SDLPlatform.cpp
@@ -483,6 +483,8 @@ void SDLPlatform::DrawableFromWindow(int wx, int wy, int &dx, int &dy) const
 void SDLPlatform::HandleMouseMotion(const SDL_MouseMotionEvent &motion)
 {
 	DrawableFromWindow(motion.x, motion.y, m_mouseX, m_mouseY);
+	::g_posixCursorX = m_mouseX;
+	::g_posixCursorY = m_mouseY;
 }
 
 void SDLPlatform::HandleMouseButton(const SDL_MouseButtonEvent &button)
@@ -505,6 +507,8 @@ void SDLPlatform::HandleMouseButton(const SDL_MouseButtonEvent &button)
 	DrawableFromWindow(button.x, button.y, mx, my);
 	m_mouseX = mx;
 	m_mouseY = my;
+	::g_posixCursorX = mx;
+	::g_posixCursorY = my;
 
 	// Skip mouse events if ImGui wants to capture them
 	if (ImGui::GetIO().WantCaptureMouse) return;
@@ -547,5 +551,13 @@ void SDLPlatform::HandleWindowEvent(const SDL_WindowEvent &window)
 }
 
 } // namespace orbiter
+
+// Global scope — the posix GetCursorPos() stub in OrbiterPlatform.h reads
+// these directly. Updated by orbiter::SDLPlatform::HandleMouse{Motion,Button}
+// so DefaultPanel::GetButtonState's per-frame hit-test sees a live cursor
+// position (without this, side-row MFD function buttons light up on press
+// but never fire — #58 follow-on).
+int g_posixCursorX = 0;
+int g_posixCursorY = 0;
 
 #endif // !_WIN32


### PR DESCRIPTION
## Summary

Four coordinated fixes restore the generic-cockpit MFD on macOS so it matches the Windows D3D9 reference:

- **BlitQuad** no longer composites with GL_BLEND. DX7's \`IDirectDrawSurface::Blt\` is a raw copy, and the MFD \`surf→tex\` blit runs right after \`Fill(0x000000)\` clears alpha=0 — every cleared pixel was keeping the previous frame's content, the trail streaks in #58.
- **BlitQuad** picks a UV orientation based on whether the source is a render target. FBO-rendered surfaces store their visual top at OGL v=1, file-loaded BMPs at v=0; without the split, chained FBO→FBO blits (\`tapes1→surf→tex\`) collected an extra Y-flip per hop and the Surface MFD tape/horizon labels came out mirrored.
- **clbkRender2DPanel** flips tv for MFD slot groups only (texIdx in \`[TEXIDX_MFD0, TEXIDX_MFD0+MAXMFD)\`). MFD textures live in FBO orientation; the panel mesh's tv assumes D3D's \"v=0 at top\". Scoping to MFD slots avoids flipping the HUD font atlas, which also carries \`OAPISURFACE_RENDERTARGET\` but holds BMP-oriented content.
- **OGLSurface::Fill** treats alpha=0 input as opaque. DX7 callers pass \`0xRRGGBB\` expecting full coverage; leaving alpha=0 made the MFD background and attitude-ball sky/ground transparent, so the 3D scene bled through.

Also wires up \`GetCursorPos\` via SDL tracking — the posix stub returned \`(0,0)\`, so \`DefaultPanel::GetButtonState\`'s per-frame hit-test reset \`activemfd\` every tick and MFD side-row function buttons (REF/TGT/NT/…) never reached \`ConsumeButton\`. \`SDLPlatform\` now updates \`g_posixCursorX/Y\` in drawable pixels and the stub reads them.

## Test plan

- [x] Build clean: \`cmake --build out/build/macos-arm64-debug --parallel 8\`
- [x] Demo/Virtual cockpit → Atlantis generic glass cockpit:
  - [x] Induce RCS rotation → Surface MFD compass/tape no longer streaks
  - [x] GS/ALT/VSI tape labels upright (no mirrored \"7\" looking like \"⌐\")
  - [x] Attitude ball pitch labels 30/40/50/60 upright at all banks
  - [x] MFD background opaque (3D scene doesn't bleed through)
  - [x] Attitude ball shows sky-blue top / orange ground
- [x] MFD function buttons fire: click PWR/SEL/MNU and REF/TGT/NT/MOD/FRM (left) + IAS/TAS/GS/OS/HUD (right); each triggers its MFD action
- [x] Autopilot row (KILL ROT, HORZ LVL, PRO GRD…) still clickable

## Known follow-ups (not blocking)

- Orbit HUD refname (\"EARTH\") appears slightly clipped at the center marker. Likely a pre-existing position mismatch in \`HUD::TexBltString\` self-blit — tracking separately.

Fixes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)