### PR TITLE
macos: fix Launchpad Video tab garbage Width/Height values

### DIFF
--- a/OVP/OGLClient/OGLLaunchpad.cpp
+++ b/OVP/OGLClient/OGLLaunchpad.cpp
@@ -92,14 +92,23 @@ void OGLLaunchpad::InitFromConfig()
 				return (long long)a.first * a.second > (long long)b.first * b.second;
 			});
 	}
-	// Pick the entry that matches the saved window size, fallback to entry 0.
-	m_vid.modeIndex = 0;
+	// Pick the entry that matches the saved window size. If nothing matches
+	// (e.g. first-run with the compiled 800x600 default on macOS where no
+	// SDL display mode is that small), fall back to the largest available
+	// mode and sync winW/winH to it so the "Width"/"Height" inputs mirror
+	// the Resolution combo. Without the sync the two drift out of step (#34).
+	m_vid.modeIndex = -1;
 	for (size_t i = 0; i < m_vid.modeList.size(); ++i) {
 		if (m_vid.modeList[i].first == m_vid.winW &&
 			m_vid.modeList[i].second == m_vid.winH) {
 			m_vid.modeIndex = (int)i;
 			break;
 		}
+	}
+	if (m_vid.modeIndex < 0 && !m_vid.modeList.empty()) {
+		m_vid.modeIndex = 0;
+		m_vid.winW = m_vid.modeList[0].first;
+		m_vid.winH = m_vid.modeList[0].second;
 	}
 
 	// Splitter positions persisted across runs
@@ -1099,16 +1108,32 @@ void OGLLaunchpad::RenderTabVideo(float availH)
 		ImGui::TextDisabled("(SDL display modes unavailable — using manual size)");
 	}
 
-	// Manual width / height for users who need an off-list size.
+	// Manual width / height for users who need an off-list size. After any
+	// manual edit, re-match against the mode list so the Resolution combo
+	// either snaps to the matching entry or shows "(custom)" rather than
+	// drifting stale behind the inputs (#34 acceptance criterion).
 	ImGui::PushItemWidth(120.0f);
+	bool winEdited = false;
 	if (ImGui::InputInt("Width",  &m_vid.winW, 0)) {
 		if (m_vid.winW < 320) m_vid.winW = 320;
+		winEdited = true;
 	}
 	ImGui::SameLine();
 	if (ImGui::InputInt("Height", &m_vid.winH, 0)) {
 		if (m_vid.winH < 240) m_vid.winH = 240;
+		winEdited = true;
 	}
 	ImGui::PopItemWidth();
+	if (winEdited) {
+		m_vid.modeIndex = -1;
+		for (size_t i = 0; i < m_vid.modeList.size(); ++i) {
+			if (m_vid.modeList[i].first == m_vid.winW &&
+				m_vid.modeList[i].second == m_vid.winH) {
+				m_vid.modeIndex = (int)i;
+				break;
+			}
+		}
+	}
 
 	ImGui::Spacing();
 	ImGui::TextDisabled("Mode");

--- a/Src/Orbiter/Config.cpp
+++ b/Src/Orbiter/Config.cpp
@@ -860,10 +860,26 @@ void Config::SetDefaults ()
 	bEchoAll = bEchoAll_default;
 	memset (&rLaunchpad, 0, sizeof(RECT));
 
-	RECT r;
-	GetWindowRect (GetDesktopWindow(), &r);
-	CfgDevPrm_default.WinW = r.right-r.left; CfgDevPrm_default.WinH = r.bottom-r.top;
-	// use the screen size as the default render window size
+	// Use the desktop size as the default render window size. On non-Win32
+	// the posix GetWindowRect/GetDesktopWindow stubs return FALSE without
+	// touching `r` — leaving it uninitialised here populated CfgDevPrm with
+	// stack garbage that surfaced as "Width: 20310460, Height: 0" in the
+	// Launchpad Video tab (#34). Zero-init r and only overwrite the compiled
+	// 800x600 defaults when the call actually produced a usable rect.
+	RECT r = {0, 0, 0, 0};
+	if (GetWindowRect (GetDesktopWindow(), &r) && r.right > r.left && r.bottom > r.top) {
+		CfgDevPrm_default.WinW = r.right-r.left;
+		CfgDevPrm_default.WinH = r.bottom-r.top;
+	}
+#ifndef _WIN32
+	// Posix builds lose the Win32 desktop probe above, and 800x600 is too
+	// cramped for a modern render window. Match the SDLPlatform fallback
+	// (Orbiter.cpp:628-629) so the first-run window opens at a usable size.
+	else {
+		CfgDevPrm_default.WinW = 1280;
+		CfgDevPrm_default.WinH = 800;
+	}
+#endif
 
 	AmbientColour = 0x0c0c0c0c;
 

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -623,10 +623,14 @@ HRESULT Orbiter::Create (HINSTANCE hInstance)
 #else
 	bWINEenv = false;
 
-	// Initialize SDL2 platform layer
+	// Initialize SDL2 platform layer. The config bounds protect against
+	// stale uninitialised values that used to leak in via the Win32
+	// GetWindowRect stub (#34). Floor at 1024x640 so an old Orbiter.cfg
+	// produced before the #34 fix — which may have saved the 800x600
+	// fallback — doesn't open the first window uncomfortably cramped.
 	m_pSDL = new orbiter::SDLPlatform(this);
-	int sdlW = (pConfig->CfgDevPrm.WinW > 0 && pConfig->CfgDevPrm.WinW < 8192) ? pConfig->CfgDevPrm.WinW : 1280;
-	int sdlH = (pConfig->CfgDevPrm.WinH > 0 && pConfig->CfgDevPrm.WinH < 8192) ? pConfig->CfgDevPrm.WinH : 800;
+	int sdlW = (pConfig->CfgDevPrm.WinW >= 1024 && pConfig->CfgDevPrm.WinW < 8192) ? pConfig->CfgDevPrm.WinW : 1280;
+	int sdlH = (pConfig->CfgDevPrm.WinH >=  640 && pConfig->CfgDevPrm.WinH < 8192) ? pConfig->CfgDevPrm.WinH : 800;
 	if (!m_pSDL->Initialize(sdlW, sdlH))
 	{
 		LOGOUT("SDL2 initialization failed");


### PR DESCRIPTION
## Summary

Three coordinated changes stop the Video tab from leaking uninitialised stack memory into the window-size inputs:

- **\`Config.cpp\`** zero-inits the \`RECT\` before the \`GetWindowRect\` probe and only overwrites the compiled defaults when the call actually produced a usable rect. The posix stubs return FALSE without touching \`r\`, so the old code was reading back whatever was on the stack — that surfaced as **\"Width: 20310460, Height: 0\"** in the Launchpad.
- On \`!_WIN32\` the fallback is bumped to **1280x800** (matches the SDL fallback in \`Orbiter.cpp\`) so first-run windows open at a usable size instead of the Win32-era 800x600 default.
- **\`OGLLaunchpad\`** keeps the Resolution combo and the Width/Height inputs in sync in both directions: on init, if no combo entry matches the saved \`winW/winH\`, snap to the largest available mode and mirror its size into the inputs; on manual edits, re-match to the combo (or show \`(custom)\` via \`modeIndex=-1\`) so the two controls stop drifting apart.
- The SDL window bootstrap floors at **1024x640**, so a stale \`Orbiter.cfg\` saved before this fix (which may contain \`WinW=800\`, \`WinH=600\` or \`0\`) doesn't produce a cramped first-launch window.

## Test plan

- [x] Build clean
- [x] First launch with fresh config: Launchpad Video tab shows sane \`Width\`/\`Height\` (matches first Resolution entry), window opens at 1280x800 or larger
- [x] Select a different Resolution in the combo → Width/Height mirror it
- [x] Edit Width manually → Resolution combo switches to matching entry or shows \`(custom)\`
- [x] Stale cfg with small WinW/WinH → startup window still opens at a usable size (>= 1024x640)

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)