### PR TITLE
macos: Launchpad/DlgInfo polish batch (#30, #32, #38)

### DIFF
--- a/OVP/OGLClient/OGLLaunchpad.cpp
+++ b/OVP/OGLClient/OGLLaunchpad.cpp
@@ -1399,11 +1399,25 @@ bool OGLLaunchpad::Render(bool &quit)
 		float total = bw * 2 + gap;
 		ImGui::SameLine(ImGui::GetWindowContentRegionMax().x - total);
 
+		// Tooltip + explicit style override on top of BeginDisabled() —
+		// the default DisabledAlpha (0.6) left the button nearly
+		// indistinguishable from the active state against our theme (#30).
 		bool canLaunch = !m_selectedScenario.empty();
-		if (!canLaunch) ImGui::BeginDisabled();
+		if (!canLaunch) {
+			ImGui::BeginDisabled();
+			ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.25f, 0.25f, 0.28f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.25f, 0.25f, 0.28f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive,  ImVec4(0.25f, 0.25f, 0.28f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_Text,          ImVec4(0.55f, 0.55f, 0.58f, 1.0f));
+		}
 		if (ImGui::Button("Launch Orbiter", ImVec2(bw, 0)))
 			launch = true;
-		if (!canLaunch) ImGui::EndDisabled();
+		if (!canLaunch) {
+			ImGui::PopStyleColor(4);
+			ImGui::EndDisabled();
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				ImGui::SetTooltip("Select a scenario from the list to enable launch.");
+		}
 
 		ImGui::SameLine();
 		if (ImGui::Button("Exit", ImVec2(bw, 0)))

--- a/Orbitersdk/samples/AscentMFD/CMakeLists.txt
+++ b/Orbitersdk/samples/AscentMFD/CMakeLists.txt
@@ -4,6 +4,12 @@
 # The target directory for plugin DLLs
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ORBITER_BINARY_PLUGIN_DIR})
 
+# Sibling .info metadata so the Launchpad groups this sample alongside
+# the other Developer-category plugins (Framerate, Meshdebug) rather than
+# the default "Miscellaneous" bucket where it was showing up unannotated
+# as a user-facing plugin (#32).
+include(${CMAKE_SOURCE_DIR}/cmake/orbiter_module_info.cmake)
+
 add_library(AscentMFD MODULE
 	AscentMFD.cpp
 	AscentMFD.rc
@@ -41,6 +47,12 @@ if(APPLE OR UNIX)
 endif()
 
 install(TARGETS AscentMFD
-	LIBRARY	
+	LIBRARY
 	DESTINATION ${ORBITER_INSTALL_PLUGIN_DIR}
-) 
+)
+
+orbiter_module_info(AscentMFD
+	CATEGORY "Developer resources and samples"
+	DESCRIPTION "ASCENT MFD:\n\nAscent profile analysis MFD — SDK sample demonstrating custom MFD registration, trajectory plotting and vessel parameter queries. Source under Orbitersdk/samples/AscentMFD. Engage from any vessel's MFD mode list."
+)
+

--- a/Src/Orbiter/DlgInfo.cpp
+++ b/Src/Orbiter/DlgInfo.cpp
@@ -6,6 +6,7 @@
 // ======================================================================
 #include "DlgInfo.h"
 #include "Celbody.h"
+#include "Vessel.h"
 #include "Psys.h"
 #include "Astro.h"
 #include "Element.h"
@@ -14,10 +15,19 @@
 #include "IconsFontAwesome6.h"
 
 extern PlanetarySystem *g_psys;
+extern Vessel          *g_focusobj;
 
 DlgInfo::DlgInfo() : ImGuiDialog(ICON_FA_CIRCLE_INFO " Orbiter: Object info", {753,423}) {
 	SetHelp("html/orbiter.chm", "/objinfo.htm");
-	m_SelectedTarget = g_psys->GetStar(0)->Name();
+	// Default to the current focus vessel so Ctrl+I opens on the object
+	// the user is actually flying, not the star at the top of the tree
+	// (#38). Fall back to the primary star if the dialog is constructed
+	// before a focus vessel exists (unlikely — EnsureEntry is bound to
+	// the in-sim Info command — but cheap to guard against).
+	if (g_focusobj)
+		m_SelectedTarget = g_focusobj->Name();
+	else
+		m_SelectedTarget = g_psys->GetStar(0)->Name();
 }
 
 void DlgInfo::AddCbodyNode(const CelestialBody *cbody) {


### PR DESCRIPTION
## Summary

Three small UX fixes grouped into one PR:

- **[#30](https://github.com/kanik0/orbiter/issues/30) Launch button disabled state** — the \`BeginDisabled()\` path was already gated, but ImGui's default \`DisabledAlpha\` (0.6) against our theme left the button looking identical to the active state. Explicit grey \`PushStyleColor\` + muted text + hover tooltip make the disabled state obvious.
- **[#38](https://github.com/kanik0/orbiter/issues/38) DlgInfo default selection** — Ctrl+I now opens on the current focus vessel instead of \"Sol\". Falls back to the primary star if constructed before any focus exists.
- **[#32](https://github.com/kanik0/orbiter/issues/32) AscentMFD category** — ships with a sibling \`.info\` sidecar placing it under \"Developer resources and samples\" alongside Framerate and Meshdebug, instead of the unlabelled \"Miscellaneous\" bucket.

[#35](https://github.com/kanik0/orbiter/issues/35) (MSAA combo missing) is deferred by design — the OGLClient scene pipeline doesn't route through an MSAA-configurable path today. Closing that issue separately with a pointer to the M22.c roadmap follow-up rather than surfacing a non-functional control.

## Test plan

- [x] Launchpad Scenarios tab, no selection → Launch Orbiter button is visibly grey with tooltip
- [x] Pick any scenario → button lights up normally, launches on click
- [x] In-sim Ctrl+I → DlgInfo opens with the focus vessel (GL-01 in Demo/Atlantis) as the initial selection
- [x] Launchpad Modules tab → AscentMFD appears under \"Developer resources and samples\" with description

Fixes #30
Fixes #32
Fixes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)