### PR TITLE
macos: fix atmospheric scattering invisible on Earth limb (#26)

### DIFF
--- a/OVP/OGLClient/OGLAtmosphere.cpp
+++ b/OVP/OGLClient/OGLAtmosphere.cpp
@@ -6,6 +6,7 @@
 #include "OGLAtmosphere.h"
 #include "OGLShaderMgr.h"
 
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 
@@ -33,17 +34,26 @@ OGLAtmosphere::OGLAtmosphere(OBJHANDLE hPlanet, ShaderMgr *shaderMgr)
 
 	const ATMCONST *atm = oapiGetPlanetAtmConstants(hPlanet);
 	if (atm) {
-		m_atmoAlt    = atm->altlimit;
+		// `altlimit` is Orbiter's physics cutoff (e.g. Earth: 2500 km) — far
+		// above the visible atmosphere. `horizonalt` is the "visible top of
+		// atmosphere" used by the legacy HazeMgr (e.g. Earth: 80 km,
+		// Mars: 60 km) and is the right shell for single-scatter rendering.
+		// Using altlimit inflated the shell 30× and spread density over km
+		// that contribute nothing, leaving the integral imperceptible (#26).
+		m_atmoAlt    = atm->horizonalt > 0 ? atm->horizonalt : atm->altlimit;
 		m_horizonAlt = atm->horizonalt;
 		m_skyColor   = atm->color0;
 	}
 
-	// Scale heights scale with the atmosphere thickness; anchor to Earth so
-	// worlds with significantly thicker (Venus, Titan) or thinner (Mars)
-	// shells give plausible gradients without hand-tuning every body.
+	// Earth's real scale heights (~8.5 km Rayleigh, ~1.2 km Mie) are the
+	// right defaults for the scatter integral; we tweak within a sane band
+	// per body. The previous altRatio scaling anchored to altlimit flattened
+	// the exponential falloff to useless levels (scaleR ≈ 250 km instead of
+	// 8.5 km for Earth).
 	const float altRatio = float(std::max(m_atmoAlt, 1000.0)) / kEarthAtmoAlt;
-	m_scaleR = std::max(2000.0f, kEarthScaleR * altRatio);
-	m_scaleM = std::max(300.0f,  kEarthScaleM * altRatio);
+	const float scaleClamp = std::clamp(altRatio, 0.5f, 4.0f);
+	m_scaleR = kEarthScaleR * scaleClamp;
+	m_scaleM = kEarthScaleM * scaleClamp;
 
 	// Tint the sun radiance by the module-provided sky colour so the dominant
 	// wavelengths match (Orbiter's color0 already encodes the observed hue).
@@ -57,8 +67,8 @@ OGLAtmosphere::OGLAtmosphere(OBJHANDLE hPlanet, ShaderMgr *shaderMgr)
 
 	// Denser shells (Venus' 90-bar, Titan's 1.5-bar) scatter harder — scale
 	// the Mie coefficient, which dominates the near-horizon haze, by the
-	// thickness ratio.
-	m_betaM = kEarthBetaM * altRatio;
+	// thickness ratio (clamped for the same reason as the scale heights).
+	m_betaM = kEarthBetaM * scaleClamp;
 
 	char name[64] = {0};
 	oapiGetObjectName(hPlanet, name, 64);
@@ -82,7 +92,7 @@ void OGLAtmosphere::Render(const float *vp,
                            const VECTOR3 &camPos, const VECTOR3 &sunPos,
                            double planetRadius, const VECTOR3 &planetPos)
 {
-	if (!m_hasAtmo || !m_shader || !m_quadVAO || !vp) return;
+	if (!m_hasAtmo || !m_shader || !m_quadVAO) return;
 
 	// Camera position in the planet-local frame, in absolute metres. The
 	// scatter shader lives entirely in metres so it can compute exp(-h/H)
@@ -92,6 +102,7 @@ void OGLAtmosphere::Render(const float *vp,
 		float(camPos.y - planetPos.y),
 		float(camPos.z - planetPos.z)
 	};
+	(void)vp;  // legacy uniform: we now build rays from camera axes directly
 
 	// Sun direction in the same frame — a world-frame unit vector is fine;
 	// Orbiter's world axes are invariant under the planet translation.
@@ -102,12 +113,32 @@ void OGLAtmosphere::Render(const float *vp,
 		float(sd.x / sdLen), float(sd.y / sdLen), float(sd.z / sdLen)
 	};
 
+	// Camera basis directly, avoiding an in-shader inverse-VP reconstruction.
+	// With Orbiter's far plane at 1e10 m the VP^-1 route crushes NDC into a
+	// single ray direction under float32 precision — every pixel then sees
+	// the atmosphere shell and the discard test fails (symptom: full-screen
+	// atmosphere tint, #26). Building the ray from camera axes + fov keeps
+	// every intermediate in a well-behaved range.
+	MATRIX3 camRot;
+	oapiCameraRotationMatrix(&camRot);
+	const float camToWorld[9] = {
+		(float)camRot.m11, (float)camRot.m21, (float)camRot.m31,  // camera +X in world
+		(float)camRot.m12, (float)camRot.m22, (float)camRot.m32,  // camera +Y in world
+		(float)camRot.m13, (float)camRot.m23, (float)camRot.m33,  // camera forward in world
+	};
+	const double fov       = oapiCameraAperture() * 2.0;
+	const float  tanHalf   = (float)std::tan(fov * 0.5);
+	GLint  vpDims[4];
+	glGetIntegerv(GL_VIEWPORT, vpDims);
+	const float  aspect    = (vpDims[3] > 0) ? (float)vpDims[2] / (float)vpDims[3] : 1.0f;
+
 	const float atmoRadius = float(planetRadius + m_atmoAlt);
 	const float planetR    = float(planetRadius);
 
 	glUseProgram(m_shader);
-	glUniformMatrix4fv(m_shaderMgr->GetUniformLoc(m_shader, "uViewProj"),
-	                   1, GL_FALSE, vp);
+	glUniformMatrix3fv(m_shaderMgr->GetUniformLoc(m_shader, "uCamToWorld"), 1, GL_FALSE, camToWorld);
+	glUniform1f (m_shaderMgr->GetUniformLoc(m_shader, "uTanHalfFov"), tanHalf);
+	glUniform1f (m_shaderMgr->GetUniformLoc(m_shader, "uAspect"),     aspect);
 	glUniform3fv(m_shaderMgr->GetUniformLoc(m_shader, "uCamPosPlanet"), 1, camRel);
 	glUniform1f (m_shaderMgr->GetUniformLoc(m_shader, "uPlanetRadius"), planetR);
 	glUniform1f (m_shaderMgr->GetUniformLoc(m_shader, "uAtmoRadius"),   atmoRadius);

--- a/OVP/OGLClient/shaders/scatter.frag
+++ b/OVP/OGLClient/shaders/scatter.frag
@@ -13,7 +13,9 @@
 
 in vec2 vNdc;
 
-uniform mat4 uViewProj;       // same VP the planet surface pass used
+uniform mat3 uCamToWorld;     // camera basis in world (cols = X_cam, Y_cam, forward_cam)
+uniform float uTanHalfFov;    // tan(fov_y / 2)
+uniform float uAspect;        // viewport width / height
 uniform vec3 uCamPosPlanet;   // camera position in planet-local frame [m]
 uniform float uPlanetRadius;  // planet radius [m]
 uniform float uAtmoRadius;    // planet radius + atmosphere altitude [m]
@@ -28,18 +30,14 @@ uniform float uExposure;      // atmosphere-only exposure multiplier
 
 out vec4 FragColor;
 
-// Reconstruct a unit world-space view direction from NDC using the inverse VP.
-vec3 ndcToWorldDir(mat4 invVP, vec2 ndc) {
-    vec4 nh = invVP * vec4(ndc, -1.0, 1.0);
-    vec4 fh = invVP * vec4(ndc,  1.0, 1.0);
-    vec3 n  = nh.xyz / nh.w;
-    vec3 f  = fh.xyz / fh.w;
-    return normalize(f - n);
-}
-
 void main() {
-    mat4 invVP = inverse(uViewProj);
-    vec3 rd = ndcToWorldDir(invVP, vNdc);
+    // Camera-local ray direction for this NDC sample: +X right, +Y up,
+    // +Z forward (the forward-is-+Z convention matches the camera basis we
+    // upload from oapiCameraRotationMatrix).
+    vec3 dirCam = normalize(vec3(vNdc.x * uAspect * uTanHalfFov,
+                                 vNdc.y * uTanHalfFov,
+                                 1.0));
+    vec3 rd = uCamToWorld * dirCam;
     vec3 ro = uCamPosPlanet;
     vec3 C  = vec3(0.0);
 


### PR DESCRIPTION
## Summary

Three root causes stacked — the M4 scatter pass was technically running, but produced either nothing or a full-screen tint instead of a limb halo:

1. **Wrong shell radius.** \`OGLAtmosphere\` used Orbiter's \`altlimit\` (2,500 km for Earth) as the scatter shell. \`altlimit\` is the *physics* cutoff; \`horizonalt\` (80 km for Earth) is what the Win32 HazeMgr uses and what Rayleigh/Mie integrals expect. The 30× inflated shell spread density over kilometres that contributed nothing. Switched to \`horizonalt\` (fallback to \`altlimit\` if absent).

2. **Wrong scale heights.** The per-planet scale heights were rescaled by the same \`altRatio\`, so Earth was computing scatter with scaleR ≈ 253 km instead of the canonical 8.5 km. Clamped the ratio to \`[0.5, 4.0]\` so Earth gets realistic 8.5 / 1.2 km scale heights and thicker worlds (Venus, Titan) still get a proportional bump without drifting into nonsense.

3. **Precision blow-up in ray reconstruction.** The frag shader reconstructed view rays by inverting \`uViewProj\` and projecting NDC through it. With the scene's far plane at 1e10 m, the intermediate world-space points had magnitudes ~1e10; under float32 in the fragment shader, every NDC collapsed to the same ray direction — the atmosphere shell appeared to be hit by every pixel (full-screen tint). Replaced the in-shader VP inverse with a direct camera-basis ray build: upload \`oapiCameraRotationMatrix\` as a mat3 plus \`tan(fov/2)\` and the viewport aspect, then reconstruct the ray in well-conditioned ranges.

## Verification

- \`Demo/Today\` (Earth from 32 Mm): day-side blue haze visible, terminator band, limb glow against space
- Atmosphere absent on Moon (no crash / no spurious halo — \`oapiPlanetHasAtmosphere\` gates init correctly)
- Log confirms new shell parameters for Earth: \`altlimit=80000m scaleR=8095m scaleM=1143m\` (was \`altlimit=2500000m scaleR=253 km scaleM=35.7 km\`)

Separate follow-up: the underlying Earth texture is still chunky low-res (#36 / M22.d texture pack) — orthogonal to the scattering fix.

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)