### PR TITLE
macos: port LuaInline + Interpreter threading to std::thread (#22)

### DIFF
--- a/Src/Module/LuaScript/LuaInline/CMakeLists.txt
+++ b/Src/Module/LuaScript/LuaInline/CMakeLists.txt
@@ -1,17 +1,13 @@
 # Copyright (c) Martin Schweiger
 # Licensed under the MIT License
 
-# Core library to go to the Orbiter main directory
+# Core library to go to the Orbiter main directory. Both the Win32
+# .dll and the POSIX .dylib / .so need to land in the Orbiter root so
+# the loader (`Script.cpp` path=".") can find them — LuaInline.cpp
+# now uses std::thread / std::condition_variable (#22) so there's no
+# platform-specific quarantine any more.
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ORBITER_BINARY_ROOT_DIR})
-# NOTE: on macOS / Linux we deliberately do NOT set LIBRARY_OUTPUT_DIRECTORY
-# to the root. LuaInline.cpp still uses Win32 threading (_beginthreadex,
-# WaitForSingleObject, TerminateThread) which is stubbed on POSIX. Loading
-# the dylib successfully — rather than silently failing to locate it —
-# exposes a SIGSEGV when a vessel (e.g. DeltaGlider::AAPSubsystem) calls
-# oapiExecScriptCmd. Until LuaInline is ported to std::thread, leave the
-# dylib in Modules/ where the loader won't find it, keeping the current
-# "silent-broken scripting, no crash" behaviour.
-# See GitHub issue tracked under label `platform:macos`, `scope:lua`.
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${ORBITER_BINARY_ROOT_DIR})
 
 add_library(LuaInline SHARED
 	LuaInline.cpp
@@ -39,6 +35,20 @@ set_target_properties(LuaInline
 	PROPERTIES
 	FOLDER Modules/Lua
 )
+
+# LuaInline lives in the Orbiter root, but its transitive dep
+# libLuaInterpreter.dylib sits in Modules/ alongside the other plugins.
+# Without an explicit rpath hint dyld only checks siblings of LuaInline and
+# the link fails. Keep the same block on Linux (RUNPATH uses $ORIGIN).
+if(APPLE)
+	set_target_properties(LuaInline PROPERTIES
+		BUILD_RPATH   "@loader_path/Modules"
+		INSTALL_RPATH "@loader_path/Modules")
+elseif(UNIX)
+	set_target_properties(LuaInline PROPERTIES
+		BUILD_RPATH   "\$ORIGIN/Modules"
+		INSTALL_RPATH "\$ORIGIN/Modules")
+endif()
 
 
 # Installation

--- a/Src/Module/LuaScript/LuaInline/LuaInline.cpp
+++ b/Src/Module/LuaScript/LuaInline/LuaInline.cpp
@@ -27,9 +27,8 @@
 #ifdef _WIN32
 #include <direct.h>
 #endif
-#ifdef _WIN32
-#include <process.h>
-#endif
+#include <chrono>
+#include <future>
 
 // ==============================================================
 // class InterpreterList::Environment: implementation
@@ -38,41 +37,46 @@ InterpreterList::Environment::Environment()
 {
 	cmd = NULL;
 	singleCmd = false;
-	hThread = NULL;
 	interp = CreateInterpreter ();
 }
 
 InterpreterList::Environment::~Environment()
 {
-	if (interp) {
-		if (hThread) {
-			termInterp = true;
-			interp->Terminate();
-			interp->EndExec(); // give the thread opportunity to close
+	if (!interp) return;
+	if (thread.joinable()) {
+		// Signal the worker to exit its WaitExec and unwind. EndExec hands
+		// the execution slot back so the thread can observe termInterp.
+		termInterp = true;
+		interp->Terminate();
+		interp->EndExec();
 
-			if (WaitForSingleObject (hThread, 1000) != 0) {
-				oapiWriteLog((char*)"LuaInline: timeout while waiting for interpreter thread");
-				TerminateThread (hThread, 0);
-			}
-			CloseHandle (hThread);
+		// std::thread has no timed join, so run the join on a helper and
+		// wait up to 1 second — matches the old WaitForSingleObject(1000)
+		// fallback. If the worker is wedged we detach rather than calling
+		// TerminateThread (POSIX has no safe equivalent, and even on
+		// Windows this path was a last resort). Detaching leaks the worker
+		// to process exit; oapiWriteLog surfaces it so it isn't silent.
+		auto joiner = std::async(std::launch::async,
+			[this]{ thread.join(); });
+		if (joiner.wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
+			oapiWriteLog((char*)"LuaInline: timeout while waiting for interpreter thread");
+			thread.detach();
 		}
-		delete interp;
 	}
+	delete interp;
 }
 
 Interpreter *InterpreterList::Environment::CreateInterpreter ()
 {
-	unsigned id;
 	termInterp = false;
 	interp = new Interpreter ();
 	interp->Initialise();
-	hThread = (HANDLE)_beginthreadex (NULL, 4096, &InterpreterThreadProc, this, 0, &id);
+	thread = std::thread(&InterpreterList::Environment::InterpreterThreadProc, this);
 	return interp;
 }
 
-unsigned int WINAPI InterpreterList::Environment::InterpreterThreadProc (LPVOID context)
+void InterpreterList::Environment::InterpreterThreadProc (InterpreterList::Environment *env)
 {
-	InterpreterList::Environment *env = (InterpreterList::Environment*)context;
 	Interpreter *interp = env->interp;
 	// interpreter loop
 	for (;;) {
@@ -89,9 +93,7 @@ unsigned int WINAPI InterpreterList::Environment::InterpreterThreadProc (LPVOID 
 		if (interp->Status() == 1) break;
 		interp->EndExec();  // return control
 	}
-	interp->EndExec();  // return mutex (is this necessary?)
-	_endthreadex(0);
-	return 0;
+	interp->EndExec();  // return execution slot
 }
 
 

--- a/Src/Module/LuaScript/LuaInline/LuaInline.h
+++ b/Src/Module/LuaScript/LuaInline/LuaInline.h
@@ -24,6 +24,7 @@
 #define __LUAINLINE_H
 
 #include "Interpreter.h"
+#include <thread>
 
 // ==============================================================
 // class InterpreterList: interface
@@ -35,11 +36,11 @@ public:
 		~Environment();
 		Interpreter *CreateInterpreter ();
 		Interpreter *interp;  // interpreter instance
-		HANDLE hThread;       // interpreter thread
+		std::thread  thread;  // interpreter worker thread
 		bool termInterp;      // interpreter kill flag
 		bool singleCmd;       // terminate after single command
 		char *cmd;            // interpreter command
-		static unsigned int WINAPI InterpreterThreadProc (LPVOID context);
+		static void InterpreterThreadProc (Environment *env);
 	};
 
 	InterpreterList (HINSTANCE hDLL);

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
@@ -8,6 +8,7 @@
 #include "MFDAPI.h"
 #include "DrawAPI.h"
 #include "gcCoreAPI.h"
+#include <chrono>
 #include <list>
 
 using std::min;
@@ -69,9 +70,8 @@ Interpreter::Interpreter ()
 	lua_pushlightuserdata (L, this);
 	lua_setfield (L, LUA_REGISTRYINDEX, "interp");
 
-	hExecMutex = CreateMutex (NULL, TRUE, NULL);
-	hWaitMutex = CreateMutex (NULL, FALSE, NULL);
-
+	// Start with the execution slot owned (matches CreateMutex(…,TRUE,…)).
+	m_execLocked = true;
 }
 
 void Interpreter::LazyInitGCCore() {
@@ -113,9 +113,6 @@ int Interpreter::LuaCall(lua_State *L, int narg, int nres)
 Interpreter::~Interpreter ()
 {
 	lua_close (L);
-
-	if (hExecMutex) CloseHandle (hExecMutex);
-	if (hWaitMutex) CloseHandle (hWaitMutex);
 }
 
 void Interpreter::Initialise ()
@@ -677,17 +674,36 @@ void Interpreter::lua_pushsketchpad (lua_State *L, oapi::Sketchpad *skp)
 
 void Interpreter::WaitExec (DWORD timeout)
 {
-	// Called by orbiter thread or interpreter thread to wait its turn
-	// Orbiter waits for the script for 1 second to return
-	WaitForSingleObject (hWaitMutex, timeout); // wait for synchronisation mutex
-	WaitForSingleObject (hExecMutex, timeout); // wait for execution mutex
-	ReleaseMutex (hWaitMutex);              // release synchronisation mutex
+	// Called by the orbiter thread or the interpreter thread to wait for
+	// its turn. Mirrors the original two-mutex Win32 pattern: only one
+	// thread holds the execution slot at a time, and callers block until
+	// the current holder relinquishes it via EndExec(). INFINITE timeout
+	// (the default — 0xFFFFFFFF) maps to an unbounded wait; any other
+	// value is interpreted as milliseconds, returning silently on timeout
+	// just like WaitForSingleObject did.
+	std::unique_lock<std::mutex> lk(m_execMu);
+	auto available = [this]{ return !m_execLocked; };
+	if (timeout == INFINITE) {
+		m_execCv.wait(lk, available);
+	} else {
+		m_execCv.wait_for(lk, std::chrono::milliseconds(timeout), available);
+		if (m_execLocked) return; // timed out — leave the slot as-is
+	}
+	m_execLocked = true;
 }
 
 void Interpreter::EndExec ()
 {
-	// called by orbiter thread or interpreter thread to hand over control
-	ReleaseMutex (hExecMutex);
+	// Called by the orbiter thread or the interpreter thread to hand
+	// control over to the other thread. Unlike std::mutex::unlock, the
+	// CV pattern lets either thread release the slot safely regardless
+	// of which one locked it — the original Win32 mutex relied on the
+	// same cross-thread transfer behaviour.
+	{
+		std::lock_guard<std::mutex> lk(m_execMu);
+		m_execLocked = false;
+	}
+	m_execCv.notify_all();
 }
 
 void Interpreter::frameskip (lua_State *L)

--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.h
@@ -12,6 +12,8 @@ extern "C" {
 
 #include "OrbiterAPI.h"
 #include "VesselAPI.h" // for TOUCHDOWNVTX
+#include <condition_variable>
+#include <mutex>
 #include <unordered_set>
 
 class gcCore;
@@ -1146,8 +1148,16 @@ protected:
 	static int xrsound_collect(lua_State *L);
 
 private:
-	HANDLE hExecMutex; // flow control synchronisation
-	HANDLE hWaitMutex;
+	// Flow-control between the Orbiter thread and the interpreter thread.
+	// `m_execLocked` is true while *someone* holds the "execution slot"
+	// (mirroring the Win32 Mutex initially-owned semantics — the constructor
+	// leaves the slot locked on behalf of whoever created the interpreter,
+	// so the worker thread's first WaitExec blocks until the orbiter thread
+	// calls EndExec). Cross-thread release is safe because we only touch
+	// the flag under `m_execMu`; `m_execCv` wakes up waiters.
+	std::mutex              m_execMu;
+	std::condition_variable m_execCv;
+	bool                    m_execLocked;
 	static inline gcCore *pCore;
 	static inline bool gcCoreInitialized = false;
 


### PR DESCRIPTION
## Summary

\`LuaInline\` drove the interpreter via Win32-specific primitives (\`_beginthreadex\`, \`HANDLE\`, \`WaitForSingleObject\`, \`TerminateThread\`, \`CloseHandle\`) and \`Interpreter\` used two Win32 Mutexes for flow control. Those are stubbed on POSIX — the interpreter thread never actually ran, so any \`oapiExecScriptCmd\` (e.g. DeltaGlider's \`AAPSubsystem\` constructor) touched an uninitialised \`Interpreter*\` and SIGSEGV'd. The workaround was to keep \`libLuaInline.dylib\` in \`Modules/\` where the loader couldn't find it, silently disabling scripting.

- **\`Interpreter\`** now keeps the execution slot with \`std::mutex\` + \`std::condition_variable\` + bool. Construction leaves the slot locked, mirroring \`CreateMutex(..., TRUE, ...)\`; \`WaitExec\`/\`EndExec\` pass it across threads (the CV pattern is safe against cross-thread release, which \`std::mutex\` is not). \`INFINITE\` timeouts map to unbounded \`cv::wait\`, other values to \`wait_for(milliseconds)\`.
- **\`InterpreterList::Environment\`** spawns a \`std::thread\` and joins on destruction. \`std::thread\` has no timed join, so the join runs on a helper \`std::async\` and falls back to \`detach\` after 1 s — matches the old \`WaitForSingleObject(1000)\` + \`TerminateThread\` escape valve without the forced-kill (POSIX has no safe equivalent; detach leaks the worker to process exit, surfaced via \`oapiWriteLog\`).
- **Restore \`CMAKE_LIBRARY_OUTPUT_DIRECTORY\`** on LuaInline so the dylib actually lands in the Orbiter root. Add an \`@loader_path/Modules\` rpath (POSIX \`$ORIGIN/Modules\` on Linux) so it can resolve \`libLuaInterpreter.dylib\` which still ships under \`Modules/\` alongside the other plugins.

## Test plan

- [x] Build clean
- [x] \`./Orbiter\` launches and loads \`libLuaInline.dylib\` without the rpath resolution error
- [x] Demo/Atlantis (DeltaGlider AAP uses \`oapiExecScriptCmd\` in its constructor) → no SIGSEGV
- [x] \`grep -i "luainline |interpreter|script|crash|segv"\` in stderr log is clean
- Cross-platform: the port uses standard C++17 threading so the Win32 build gets the same code path

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)