### PR TITLE
macos/linux: quick-wins batch (#33 #10 #19)

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -459,6 +459,13 @@ bool OGLClient::clbkSetSurfaceColourKey(SURFHANDLE surf, DWORD ckey)
 	return true;
 }
 
+bool OGLClient::clbkClearSurfaceColourKey(SURFHANDLE surf)
+{
+	if (!surf) return false;
+	((OGLSurface*)surf)->ClearColorKey();
+	return true;
+}
+
 DWORD OGLClient::clbkGetDeviceColour(BYTE r, BYTE g, BYTE b)
 {
 	return (DWORD)r | ((DWORD)g << 8) | ((DWORD)b << 16);

--- a/OVP/OGLClient/OGLClient.h
+++ b/OVP/OGLClient/OGLClient.h
@@ -62,6 +62,7 @@ public:
 	bool clbkGetSurfaceSize(SURFHANDLE surf, DWORD *w, DWORD *h) override;
 	void clbkIncrSurfaceRef(SURFHANDLE surf) override;
 	bool clbkSetSurfaceColourKey(SURFHANDLE surf, DWORD ckey) override;
+	bool clbkClearSurfaceColourKey(SURFHANDLE surf) override;
 	DWORD clbkGetDeviceColour(BYTE r, BYTE g, BYTE b) override;
 
 	// === Surface blitting ===

--- a/OVP/OGLClient/OGLSurface.h
+++ b/OVP/OGLClient/OGLSurface.h
@@ -90,6 +90,7 @@ public:
 	// --- Color key ----------------------------------------------------------
 
 	void  SetColorKey(DWORD ckey) { m_colorKey = ckey; m_hasColorKey = true; }
+	void  ClearColorKey()         { m_colorKey = 0;    m_hasColorKey = false; }
 	bool  HasColorKey() const { return m_hasColorKey; }
 	DWORD GetColorKey() const { return m_colorKey; }
 

--- a/Orbitersdk/include/GraphicsAPI.h
+++ b/Orbitersdk/include/GraphicsAPI.h
@@ -1156,6 +1156,16 @@ public:
 	virtual bool clbkSetSurfaceColourKey (SURFHANDLE surf, DWORD ckey) { return false; }
 
 	/**
+	 * \brief Clear any transparency colour key previously set on a surface.
+	 * \param surf surface handle
+	 * \return true on success, false if the renderer does not support
+	 *   colour-key transparency or the clear could not be applied.
+	 * \note Derived classes should overload this method if the renderer
+	 *   supports colour key transparency for surfaces.
+	 */
+	virtual bool clbkClearSurfaceColourKey (SURFHANDLE surf) { return false; }
+
+	/**
 	 * \brief Convert an RGB colour triplet into a device-specific colour value.
 	 * \param r red component
 	 * \param g green component

--- a/Sound/XRSound/src/CMakeLists.txt
+++ b/Sound/XRSound/src/CMakeLists.txt
@@ -67,6 +67,16 @@ install(TARGETS XRSound_dll
 	RUNTIME DESTINATION ${ORBITER_INSTALL_PLUGIN_DIR}
 )
 
+if(NOT WIN32)
+	# Sidecar .info for the OGL Launchpad — without it XRSound falls
+	# into the default "Miscellaneous" category with no description.
+	include(${CMAKE_SOURCE_DIR}/cmake/orbiter_module_info.cmake)
+	orbiter_module_info(XRSound_dll
+		CATEGORY "Audio"
+		DESCRIPTION "XRSOUND:\n\nOpenAL-backed audio engine for vessel sounds (engine, RCS, docking, atmospheric buffet, UI cues). Enable to hear in-sim audio. Configure per-vessel sound sets under Config/XRSound/."
+	)
+endif()
+
 ## XRSound_lib
 add_library(XRSound_lib STATIC
 	XRSound.cpp

--- a/Src/Orbiter/OrbiterAPI.cpp
+++ b/Src/Orbiter/OrbiterAPI.cpp
@@ -2037,10 +2037,11 @@ DLLEXPORT void oapiSetSurfaceColourKey (SURFHANDLE surf, DWORD ck)
 DLLEXPORT void oapiClearSurfaceColourKey (SURFHANDLE surf)
 {
 	if (!surf) return;
-	oapi::GraphicsClient *gc = g_pOrbiter->GetGraphicsClient();
-	//if (gc) gc->clbClearSurfaceColourKey (surf); // TODO
 #ifdef _WIN32
 	((LPDIRECTDRAWSURFACE7)surf)->SetColorKey (DDCKEY_SRCBLT, 0);
+#else
+	oapi::GraphicsClient *gc = g_pOrbiter->GetGraphicsClient();
+	if (gc) gc->clbkClearSurfaceColourKey (surf);
 #endif
 }
 

--- a/Src/Orbiter/UserPaths.cpp
+++ b/Src/Orbiter/UserPaths.cpp
@@ -27,6 +27,17 @@ static std::string HomeDir()
 }
 #endif
 
+#if defined(__linux__) && !defined(__APPLE__)
+// XDG Base Directory lookup: return $envVar if set and non-empty, else
+// the $HOME/-anchored fallback defined by the XDG spec.
+// https://specifications.freedesktop.org/basedir-spec/latest/
+static std::string XdgDir(const char *envVar, const char *fallbackRel)
+{
+	if (const char *v = std::getenv(envVar); v && *v) return v;
+	return HomeDir() + "/" + fallbackRel;
+}
+#endif
+
 bool EnsureDir(const std::string &path)
 {
 #ifdef _WIN32
@@ -56,8 +67,12 @@ std::string GetUserConfigDir()
 	std::string d = HomeDir() + "/Library/Application Support/Orbiter";
 	EnsureDir(d);
 	return d + "/";
+#elif defined(__linux__)
+	std::string d = XdgDir("XDG_CONFIG_HOME", ".config") + "/Orbiter";
+	EnsureDir(d);
+	return d + "/";
 #else
-	return ""; // Windows / Linux → caller uses cwd
+	return ""; // Windows → caller uses cwd
 #endif
 }
 
@@ -65,6 +80,10 @@ std::string GetUserLogPath()
 {
 #if defined(__APPLE__)
 	std::string d = HomeDir() + "/Library/Logs/Orbiter";
+	EnsureDir(d);
+	return d + "/Orbiter.log";
+#elif defined(__linux__)
+	std::string d = XdgDir("XDG_STATE_HOME", ".local/state") + "/Orbiter/log";
 	EnsureDir(d);
 	return d + "/Orbiter.log";
 #else

--- a/cmake/orbiter_module_info.cmake
+++ b/cmake/orbiter_module_info.cmake
@@ -33,7 +33,16 @@ function(orbiter_module_info target)
 	# allow callers to embed literal \n
 	string(REPLACE "\\n" "\n" _desc "${_desc}")
 
-	set(_info_path "${ORBITER_BINARY_PLUGIN_DIR}/${target}.info")
+	# The Launchpad parser (OGLLaunchpad::ScanModules) strips the "lib"
+	# prefix and file extension to build a <base>.info lookup. For
+	# targets that override OUTPUT_NAME — e.g. "XRSound_dll" → libXRSound
+	# — the sidecar must be named after the output, not the CMake target.
+	get_target_property(_out_name ${target} OUTPUT_NAME)
+	if(NOT _out_name)
+		set(_out_name "${target}")
+	endif()
+
+	set(_info_path "${ORBITER_BINARY_PLUGIN_DIR}/${_out_name}.info")
 
 	# Stage the file content via configure_file (preserves newlines that
 	# the cmake -E echo dance loses) and copy it next to the dylib at


### PR DESCRIPTION
## Summary
Three small, independent fixes bundled into one PR for review velocity. Each commit is standalone and can be cherry-picked.

- **#33** — XRSound plugin showed up under "Miscellaneous" with no description in the Launchpad Modules tab. Added a sidecar `.info` ("Audio" category) and taught `orbiter_module_info()` to respect `OUTPUT_NAME`, since XRSound's CMake target is `XRSound_dll` but its dylib (and the Launchpad's `.info` lookup key) is `XRSound`.
- **#10** — `oapiClearSurfaceColourKey()` was a silent no-op on non-Win32 with a dangling `// TODO`. Wired through a new virtual `clbkClearSurfaceColourKey()` on `GraphicsClient`, implemented in `OGLClient` via a new `OGLSurface::ClearColorKey()` (inverse of `SetColorKey`). Win32 path untouched.
- **#19** — `GetUserConfigDir()` / `GetUserLogPath()` returned `""` on Linux. Added XDG-compliant branches (`$XDG_CONFIG_HOME/Orbiter/`, `$XDG_STATE_HOME/Orbiter/log/`) with the spec-defined fallbacks. macOS and Windows branches untouched. Untested on Linux (no runner in this env) — direct parallel of the macOS branch.

## Test plan
- [x] `cmake --build out/build/macos-arm64-debug --parallel 8` — clean build
- [x] `out/build/macos-arm64-debug/Modules/Plugin/XRSound.info` generated with `[Category] Audio`
- [x] Existing plugin `.info` files (13 total) still present with unchanged names after the OUTPUT_NAME lookup change
- [x] `Demo/Earth` scenario boots without new errors or warnings in `Orbiter.log` / stderr
- [ ] Linux validation for #19 — needs a future CI run on Linux

Fixes #33
Fixes #10
Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)