### PR TITLE
macos: depth-aware bloom composite fixes atm halo overlay on vessels (#71)

### DIFF
--- a/OVP/OGLClient/OGLPostProcess.cpp
+++ b/OVP/OGLClient/OGLPostProcess.cpp
@@ -20,7 +20,7 @@ OGLPostProcess::OGLPostProcess(ShaderMgr *shaderMgr)
 	  // that the uniform plumbing lands correctly. Caller can override via
 	  // SetExposure() for HDR scenes or user preference.
 	  m_bloomThreshold(0.8f), m_bloomIntensity(0.5f), m_exposure(1.0f),
-	  m_sceneFBO(0), m_sceneColorTex(0), m_sceneDepthRBO(0),
+	  m_sceneFBO(0), m_sceneColorTex(0), m_sceneDepthTex(0),
 	  m_thresholdShader(0), m_blurShader(0), m_compositeShader(0), m_flareShader(0),
 	  m_quadVAO(0), m_quadVBO(0)
 {
@@ -55,7 +55,7 @@ bool OGLPostProcess::Init(int width, int height)
 	// Create HDR scene FBO (full resolution, float16)
 	glGenFramebuffers(1, &m_sceneFBO);
 	glGenTextures(1, &m_sceneColorTex);
-	glGenRenderbuffers(1, &m_sceneDepthRBO);
+	glGenTextures(1, &m_sceneDepthTex);
 
 	glBindTexture(GL_TEXTURE_2D, m_sceneColorTex);
 	// macOS OpenGL 4.1-via-Metal silently drops fragment writes to
@@ -87,12 +87,24 @@ bool OGLPostProcess::Init(int width, int height)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-	glBindRenderbuffer(GL_RENDERBUFFER, m_sceneDepthRBO);
-	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, width, height);
+	// Attach depth as a texture (GL_DEPTH_COMPONENT24) rather than a
+	// renderbuffer so the tonemap composite shader can sample it to mask
+	// bloom contribution at foreground pixels (issue #71). Atmospheric
+	// pixels are drawn with depth writes off so they keep the cleared
+	// 1.0 depth; vessels write their actual depth. A depth check in the
+	// composite can therefore distinguish "far / atm / sun" from
+	// "foreground / vessel" and only apply bloom to the former.
+	glBindTexture(GL_TEXTURE_2D, m_sceneDepthTex);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24,
+	             width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, nullptr);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
 	glBindFramebuffer(GL_FRAMEBUFFER, m_sceneFBO);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_sceneColorTex, 0);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, m_sceneDepthRBO);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, m_sceneDepthTex, 0);
 
 	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
 		fprintf(stderr, "[PostProcess] Scene FBO incomplete\n");
@@ -126,7 +138,7 @@ void OGLPostProcess::Release()
 {
 	if (m_sceneFBO) { glDeleteFramebuffers(1, &m_sceneFBO); m_sceneFBO = 0; }
 	if (m_sceneColorTex) { glDeleteTextures(1, &m_sceneColorTex); m_sceneColorTex = 0; }
-	if (m_sceneDepthRBO) { glDeleteRenderbuffers(1, &m_sceneDepthRBO); m_sceneDepthRBO = 0; }
+	if (m_sceneDepthTex) { glDeleteTextures(1, &m_sceneDepthTex); m_sceneDepthTex = 0; }
 	for (int i = 0; i < 2; i++) {
 		if (m_bloomFBO[i]) { glDeleteFramebuffers(1, &m_bloomFBO[i]); m_bloomFBO[i] = 0; }
 		if (m_bloomTex[i]) { glDeleteTextures(1, &m_bloomTex[i]); m_bloomTex[i] = 0; }
@@ -243,6 +255,16 @@ void OGLPostProcess::EndScene(float sunScreenX, float sunScreenY, bool sunVisibl
 	glActiveTexture(GL_TEXTURE1);
 	glBindTexture(GL_TEXTURE_2D, m_bloomEnabled ? m_bloomTex[0] : 0);
 	glUniform1i(m_shaderMgr->GetUniformLoc(m_compositeShader, "uBloom"), 1);
+
+	// Scene depth (issue #71): foreground pixels (written by the vessel
+	// pass) have depth < 1.0; background pixels (atmosphere fullscreen
+	// quad + distance-normalised planet + stars) kept the cleared 1.0.
+	// The shader uses that to mask bloom spill onto vessel silhouettes
+	// at the limb, where the bright atm halo would otherwise bleed
+	// through the hull via the bloom blur kernel.
+	glActiveTexture(GL_TEXTURE2);
+	glBindTexture(GL_TEXTURE_2D, m_sceneDepthTex);
+	glUniform1i(m_shaderMgr->GetUniformLoc(m_compositeShader, "uSceneDepth"), 2);
 
 	glUniform1f(m_shaderMgr->GetUniformLoc(m_compositeShader, "uExposure"), m_exposure);
 	glUniform1f(m_shaderMgr->GetUniformLoc(m_compositeShader, "uBloomIntensity"),

--- a/OVP/OGLClient/OGLPostProcess.h
+++ b/OVP/OGLClient/OGLPostProcess.h
@@ -62,7 +62,10 @@ private:
 	// HDR scene FBO (full resolution, RGBA16F)
 	GLuint m_sceneFBO;
 	GLuint m_sceneColorTex;
-	GLuint m_sceneDepthRBO;
+	// Depth attached as a texture (not a renderbuffer) so the tonemap
+	// composite can sample it to mask bloom contribution at foreground
+	// pixels — see issue #71.
+	GLuint m_sceneDepthTex;
 
 	// Bloom FBOs (half resolution, ping-pong for blur)
 	GLuint m_bloomFBO[2];

--- a/OVP/OGLClient/shaders/tonemap.frag
+++ b/OVP/OGLClient/shaders/tonemap.frag
@@ -10,6 +10,7 @@ in vec2 vUV;
 
 uniform sampler2D uScene;
 uniform sampler2D uBloom;
+uniform sampler2D uSceneDepth;
 uniform float     uExposure;
 uniform float     uBloomIntensity;
 
@@ -51,7 +52,18 @@ uniform int uIsHDR;
 void main() {
     vec3 scene = texture(uScene, vUV).rgb;
     if (uBloomIntensity > 0.0) {
-        scene += texture(uBloom, vUV).rgb * uBloomIntensity;
+        // Depth-aware bloom: only apply bloom where the scene depth is
+        // at the cleared far value (1.0). Vessel pixels write their real
+        // depth during the main mesh pass (< 1.0), while planets /
+        // atmosphere / stars leave the cleared depth untouched. Without
+        // this mask the bloom blur kernel spread bright atmosphere pixels
+        // at Earth's limb into neighbouring vessel silhouettes, so the
+        // hull appeared to glow with the scatter colour (issue #71).
+        // smoothstep over a small band around 1.0 keeps the transition
+        // smooth at anti-aliased vessel edges.
+        float depth = texture(uSceneDepth, vUV).r;
+        float bloomMask = smoothstep(0.9995, 0.9999, depth);
+        scene += texture(uBloom, vUV).rgb * uBloomIntensity * bloomMask;
     }
 
     vec3 mapped;


### PR DESCRIPTION
## Summary
Atmospheric halo at Earth's limb visibly bled through the vessel silhouette (DG wing going transparent against the cyan limb). The render order was already correct (planets + atm → vessels, depth writes off during atm pass per #70), so depth / z-fighting were not the cause.

**Root cause**: the **bloom pass**.

- On macOS the scene FBO is `GL_RGBA8`, not `GL_RGBA16F` (Apple Silicon GL-via-Metal silently drops float colour attachments). No real HDR headroom.
- The scatter shader's in-scatter clamps via `1 - exp(-t*uExposure)`, and at the limb that saturates to near-white cyan — luminance > the bloom threshold (0.8).
- `ApplyBloom` extracts those bright atm pixels, runs a 4-tap Gaussian blur, and the composite then **adds** the blurred halo to **every** screen pixel — including vessel hull pixels immediately adjacent to the limb. That spatial spread made the hull appear to glow cyan.
- Forcing the scatter shader to emit solid red (luminance ~0.28) kept the bloom threshold from firing, which is why that debug probe from the issue body masked the artefact.

## Fix — depth-aware bloom compositing

- Promote `m_sceneDepthRBO` (renderbuffer) to `m_sceneDepthTex` (`GL_DEPTH_COMPONENT24` texture) so the composite pass can sample the depth. The client does not use stencil, so `GL_DEPTH_STENCIL` isn't needed.
- Bind the depth texture on `TEXTURE2` at tonemap composite time and add `uniform sampler2D uSceneDepth` to `tonemap.frag`.
- Scale the bloom contribution by `smoothstep(0.9995, 0.9999, depth)` — vessel pixels (which wrote real depth < 1.0) get no bloom spill; atm / distance-normalised planet / stars / sun (all depth == 1.0) keep full bloom.

## Test plan

- [x] DG in LEO, external tracking view, vessel crossing Earth limb
   - **Before**: cyan atm halo visibly crosses the hull
   - **After**: vessel silhouette is opaque
- [x] `Demo/The 1999 solar eclipse` — sun disc bloom + lens flare still render (both at depth 1.0)
- [x] `Demo/Today` — atm glow at limb preserved on background pixels
- [x] `OGL_POSTFX_NOBLOOM=1` and `OGL_NO_POSTFX=1` escape hatches still work
- [x] No new warnings in `Orbiter.log` / stderr

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)