### PR TITLE
macos: fix atm halo overlapping vessel silhouette at planet limb

### DIFF
--- a/OVP/OGLClient/OGLAtmosphere.cpp
+++ b/OVP/OGLClient/OGLAtmosphere.cpp
@@ -155,6 +155,18 @@ void OGLAtmosphere::Render(const float *vp,
 	//   FragColor = (inscatter, alpha)
 	// src_alpha blending gives us: dst = src + dst * (1-alpha), which is the
 	// standard "sky-over-surface" compositing with alpha = 1 - transmittance.
+	//
+	// Snapshot the caller's depth/cull state: the outer planet loop draws
+	// every planet with depth write and depth test disabled, and restoring
+	// these to TRUE here would enable depth writes for the *next* planet's
+	// surface sphere. Later vessels, projected at a much larger normalized
+	// distance, then fail the GL_LESS test against that synthetic near-depth
+	// along the limb — producing a halo that bleeds across vessel silhouettes.
+	GLboolean prevDepthTest = glIsEnabled(GL_DEPTH_TEST);
+	GLboolean prevDepthMask = GL_TRUE;
+	glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
+	GLboolean prevCullFace  = glIsEnabled(GL_CULL_FACE);
+
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	// Depth test off so the quad still paints haze on the planet surface
@@ -171,9 +183,9 @@ void OGLAtmosphere::Render(const float *vp,
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 	glBindVertexArray(0);
 
-	glDepthMask(GL_TRUE);
-	glEnable(GL_DEPTH_TEST);
-	glEnable(GL_CULL_FACE);
+	glDepthMask(prevDepthMask);
+	if (prevDepthTest) glEnable(GL_DEPTH_TEST);
+	if (prevCullFace)  glEnable(GL_CULL_FACE);
 	glDisable(GL_BLEND);
 	glUseProgram(0);
 }

--- a/OVP/OGLClient/OGLvPlanet.cpp
+++ b/OVP/OGLClient/OGLvPlanet.cpp
@@ -502,6 +502,10 @@ void OGLvPlanet::RenderClouds(const float *vp, const VECTOR3 &camPos, const VECT
 	// Clouds occlude what's behind them but should not write depth — the
 	// atmosphere pass downstream needs to see the planet's depth, not the
 	// cloud shell's, otherwise the scatter integration stops on the cloud.
+	// Preserve the caller's depth-write state so we don't leak a TRUE mask
+	// back into the outer planet loop (which runs with depth writes off).
+	GLboolean prevDepthMask = GL_TRUE;
+	glGetBooleanv(GL_DEPTH_WRITEMASK, &prevDepthMask);
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glDepthMask(GL_FALSE);
@@ -510,7 +514,7 @@ void OGLvPlanet::RenderClouds(const float *vp, const VECTOR3 &camPos, const VECT
 	glDrawElements(GL_TRIANGLES, s_texSphereIndexCount, GL_UNSIGNED_INT, 0);
 	glBindVertexArray(0);
 
-	glDepthMask(GL_TRUE);
+	glDepthMask(prevDepthMask);
 	glDisable(GL_BLEND);
 	glBindTexture(GL_TEXTURE_2D, 0);
 	glUseProgram(0);


### PR DESCRIPTION
## Summary

- `OGLAtmosphere::Render` and `OGLvPlanet::RenderClouds` unconditionally reset `glDepthMask` to `GL_TRUE` on exit. `OGLScene::RenderScene` runs the whole planet loop with depth writes off and relies on every sub-pass to leave that state alone.
- After the first atm-bearing planet (Venus) renders, the leaked `TRUE` mask causes Earth's fallback textured-sphere surface pass to write depth at its normalized distance. Vessels rendered later at a much larger normalized distance fail `GL_LESS` at the limb and vanish under the already-composited atm halo — the long-standing #71 symptom.
- Both passes now snapshot the caller's depth-write (and, for atm, depth-test and cull) state on entry and restore exactly what they found.

## Root-cause walkthrough

Debug trace showed, within each `clbkRenderScene`, 10 atm calls followed by 1 vessel call (all to the HDR scene FBO=2), with clean GL state at vessel entry (`blend=0 depth=1 mask=1`). Forcing the vessel shader to opaque red and the atm shader to opaque magenta made the overlap obvious: magenta painted across the red hull at the limb. Disabling depth test for the vessel pass made the magenta disappear.

The trigger was traced to clouds/atm restoring `mask=GL_TRUE` while the outer `OGLScene` planet loop had set it to `GL_FALSE`; subsequent planet surface passes then populated the depth buffer at near-planet depths that vessels (normalized to 1000 units vs. planet at 10) could not pass.

## Test plan

- [x] DG in LEO, camera external: no halo overlap at Earth's limb
- [x] Earth surface and atmospheric haze render normally (blue gradient at limb, correct opacity)
- [x] Vessel texture and shading unaffected
- [x] No regressions on other planets with atm (Venus, Mars, Titan)
- [x] Build clean on `macos-arm64-debug` preset

Fixes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)