### PR TITLE
macos: wire Lua.Interpreter ctest rpath + RTTI stubs

### DIFF
--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -14,6 +14,29 @@ function(add_test_file test_name)
 
 	set_target_properties( ${test_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${ORBITER_BINARY_ROOT_DIR}" )
 
+	# Test binaries live at the build root next to Orbiter, but the
+	# plugin-side dylibs they link against (e.g. libLuaInterpreter) are
+	# deployed under Modules/ to match the runtime loader layout. Extend
+	# the rpath so dyld can find them without copying or symlinking.
+	if(APPLE)
+		set_target_properties(${test_name} PROPERTIES
+			BUILD_RPATH   "@loader_path;@loader_path/Modules"
+			INSTALL_RPATH "@loader_path;@loader_path/Modules"
+		)
+		# libLuaInterpreter is linked with -undefined dynamic_lookup so it
+		# can reach back into the Orbiter executable at runtime. A test
+		# harness has no such host, so dyld aborts on the first unresolved
+		# RTTI symbol (typeinfo/vtable are bound eagerly). Compile a small
+		# stubs TU into the test to provide those key symbols — it's never
+		# exercised at runtime, only needed by the loader.
+		target_sources(${test_name} PRIVATE Stubs.cpp)
+	elseif(UNIX)
+		set_target_properties(${test_name} PROPERTIES
+			BUILD_RPATH   "\$ORIGIN;\$ORIGIN/Modules"
+			INSTALL_RPATH "\$ORIGIN;\$ORIGIN/Modules"
+		)
+	endif()
+
 	target_include_directories(${test_name}
 		PRIVATE ${ORBITER_SOURCE_SDK_INCLUDE_DIR}
 		PRIVATE ${MODULE_COMMON_DIR}

--- a/Tests/Stubs.cpp
+++ b/Tests/Stubs.cpp
@@ -1,0 +1,20 @@
+// Stubs that satisfy the Orbiter-executable symbols libLuaInterpreter.dylib
+// would normally resolve against the host process. The test harness runs
+// without Orbiter, so dyld would otherwise abort on the first eager RTTI
+// lookup (typeinfo/vtable for MFD2). None of these definitions are called
+// at runtime — they exist purely so the test binary is self-contained.
+
+#define OAPI_IMPLEMENTATION
+#include "MFDAPI.h"
+
+// MFD key methods — emit the base typeinfo that MFD2's typeinfo chains to.
+MFD::MFD(DWORD w, DWORD h, VESSEL *vessel)
+	: W(w), H(h), cw(0), ch(0), pV(vessel), instr(nullptr) {}
+MFD::~MFD() {}
+
+// MFD2 key methods — emit typeinfo + vtable for MFD2 in the test binary.
+bool        MFD2::Update         (oapi::Sketchpad *)                       { return false; }
+void        MFD2::Title          (oapi::Sketchpad *, const char *) const   {}
+oapi::Pen  *MFD2::GetDefaultPen  (DWORD, DWORD, DWORD)              const  { return nullptr; }
+oapi::Font *MFD2::GetDefaultFont (DWORD)                            const  { return nullptr; }
+DWORD       MFD2::GetDefaultColour(DWORD, DWORD)                    const  { return 0; }


### PR DESCRIPTION
## Summary

Two issues made \`ctest Lua.Interpreter\` unusable:

1. **rpath miss** — The test binary lives at the build root, but \`libLuaInterpreter.dylib\` is deployed under \`Modules/\` to match the runtime loader layout. dyld aborted at startup with \`Library not loaded: @rpath/libLuaInterpreter.dylib\` because \`Modules/\` wasn't in the search list.
2. **RTTI eager bind** — Once rpath resolved, the dylib pulls in \`typeinfo for MFD2\` and \`vtable for MFD2\`. Those normally live in the Orbiter executable and resolve via \`-undefined dynamic_lookup\` when the plugin is loaded in-process. A standalone test has no such host; dyld binds RTTI eagerly and aborted with \`symbol not found in flat namespace '__ZTI4MFD2'\`.

## Fix

- \`add_test_file()\` in \`Tests/CMakeLists.txt\` now sets \`BUILD_RPATH\`/\`INSTALL_RPATH\` to include \`@loader_path/Modules\` on macOS (and \`\$ORIGIN/Modules\` on Linux for consistency).
- New \`Tests/Stubs.cpp\` provides \`MFD\` and \`MFD2\` key-method definitions so the test binary's own translation unit emits the typeinfo/vtable symbols the dylib would otherwise import from Orbiter. The stubs are never executed — they exist purely to satisfy the loader.

## Test plan

- [x] \`ctest --test-dir out/build/macos-arm64-debug -R Lua\` → passes
- [x] \`ctest --test-dir out/build/macos-arm64-debug\` (all tests) → 3/3 pass, no regression on rendering_parity
- [x] Full \`cmake --build\` clean, Orbiter itself unchanged
- [x] Verified \`otool -l Lua.Interpreter\` shows both \`@loader_path\` and \`@loader_path/Modules\` in LC_RPATH

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)