### PR TITLE
macos: fix off-by-one in vessel mesh-group texture binding

### DIFF
--- a/OVP/OGLClient/OGLvVessel.cpp
+++ b/OVP/OGLClient/OGLvVessel.cpp
@@ -723,8 +723,18 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 					glUniform1i(texLoc, 0);
 					hasTexture = true;
 				}
-			} else if (grp && grp->TexIdx > 0 && grp->TexIdx <= nTex) {
-				SURFHANDLE hSurf = oapiGetTextureHandle(hMesh, grp->TexIdx);
+			} else if (grp && grp->TexIdx < nTex) {
+				// MESHGROUPEX::TexIdx is stored 0-based by the mesh loader
+				// (Src/Orbiter/Mesh.cpp:868-869 subtracts 1 from the file's
+				// 1-based TEXTURE index; SPEC_DEFAULT = UINT_MAX flags "no
+				// texture"). The public oapiGetTextureHandle API is 1-based
+				// — it calls Mesh::GetTexture(texidx - 1) internally — so
+				// we need to shift back up by one when dereferencing. The
+				// previous `TexIdx > 0 && TexIdx <= nTex` guard on the raw
+				// value happened to bind groups with file-TEXTURE >= 2 to
+				// the *wrong* texture and silently dropped file-TEXTURE 1
+				// groups entirely (issue #96, Atlantis fuselage).
+				SURFHANDLE hSurf = oapiGetTextureHandle(hMesh, grp->TexIdx + 1);
 				if (hSurf) {
 					OGLSurface *surf = (OGLSurface*)hSurf;
 					GLuint texId = surf->GetTexture();


### PR DESCRIPTION
## Summary

\`OGLvVessel::Render\` was treating \`MESHGROUPEX::TexIdx\` as 1-based (gating with \`TexIdx > 0 && TexIdx <= nTex\` and passing the raw value to \`oapiGetTextureHandle\`). The SDK header documents it that way, but the Orbiter mesh loader actually subtracts 1 from the file's 1-based \`TEXTURE N\` directive before storing it (\`Src/Orbiter/Mesh.cpp:868-869\`), so the runtime value is 0-based with \`SPEC_DEFAULT\` (UINT_MAX) flagging "no texture". \`oapiGetTextureHandle\` itself is 1-based and does another \`-1\` internally before indexing \`Mesh::Tex[]\`.

## The visible consequence

The two shifts only cancel out when the value is left unnormalised. With the previous guard:

| File directive | Stored \`TexIdx\` | Old behaviour |
|---|---|---|
| \`TEXTURE 0\` (none) | \`UINT_MAX\` | rejected by \`<= nTex\` ✓ |
| \`TEXTURE 1\` (first texture) | \`0\` | **rejected by \`> 0\`** → untextured render |
| \`TEXTURE 2\` | \`1\` | \`oapiGetTextureHandle(h, 1)\` → \`Tex[0]\` — **wrong texture** |
| \`TEXTURE N\` (\`N >= 2\`) | \`N-1\` | binds \`Tex[N-2]\` — **wrong texture** |

Atlantis was the most obvious victim: 26 of its 59 fuselage/belly groups reference the first texture (\`MGAtlantis.dds\` — markings + thermal-tile pattern) and fell through to a flat albedo-only render, while the remaining 30 groups pulled \`cargobay.dds\` onto the wrong UVs. The net result was an almost uniformly white/grey hull.

## Diagnosis trail

Debug instrumentation dumped per-\`(mesh, group)\` \`TexIdx\` for Atlantis (\`STS-101\`):

\`\`\`
22 TexIdx=0 MtrlIdx=0                     <- file TEXTURE 1 → rejected
 4 TexIdx=0 MtrlIdx=1                     <- file TEXTURE 1 → rejected
30 TexIdx=1 MtrlIdx=0                     <- file TEXTURE 2 → bound to wrong Tex[0]
 1 TexIdx=4294967295 MtrlIdx=2            <- file TEXTURE 0 → correctly rejected
 2 TexIdx=4294967295 MtrlIdx=3            <- file TEXTURE 0 → correctly rejected
\`\`\`

## Fix

Normalise the guard to \`grp->TexIdx < nTex\` (the \`SPEC_DEFAULT\` / \`SPEC_INHERIT\` sentinels are UINT_MAX / UINT_MAX-1 and fail the unsigned bound naturally) and add the \`+1\` shift at the API call site.

## Test plan

- [x] Atlantis: fuselage shows \`United States\`, flag, and thermal-tile patterns on external view
- [x] DeltaGlider: fuselage, canopy, wing textures unchanged from the visually-acceptable prior render; animations (gear, airbrakes) still work
- [x] Shuttle-A: no regression
- [x] No vessel with a single-texture mesh regresses
- [x] Build clean on \`macos-arm64-debug\`

Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)