### PR TITLE
macos: add SDL_Haptic fallback + rumble-gain config for HapticFX

### DIFF
--- a/OVP/OGLClient/OGLLaunchpad.cpp
+++ b/OVP/OGLClient/OGLLaunchpad.cpp
@@ -814,6 +814,11 @@ void RenderJoystickPage(Config *c)
 		&c->CfgJoystickPrm.ThrottleSaturation, 0, 10000);
 	ImGui::Checkbox("Ignore initial throttle position",
 		&c->CfgJoystickPrm.bThrottleIgnore);
+
+	ImGui::Spacing();
+	ImGui::TextDisabled("Haptic feedback");
+	ImGui::SliderFloat("Rumble gain (0 disables)",
+		&c->CfgJoystickPrm.HapticGain, 0.0f, 2.0f, "%.2f");
 }
 
 void RenderCelSpherePage(Config *c)

--- a/Src/Orbiter/Config.cpp
+++ b/Src/Orbiter/Config.cpp
@@ -206,7 +206,8 @@ CFG_JOYSTICKPRM CfgJoystickPrm_default = {
 	2500,		// Deadzone (neutralise joystick axes within 20% of central position)
 	1,			// ThrottleAxis (z-axis by default)
 	9500,		// ThrottleSaturation (saturate throttle at the last 5% each end)
-	true		// bThrottleIgnore (ignore throttle setting on simulation start)
+	true,		// bThrottleIgnore (ignore throttle setting on simulation start)
+	1.0f		// HapticGain (unity = ship-tuned defaults)
 };
 
 CFG_UIPRM CfgUIPrm_default = {
@@ -564,6 +565,11 @@ bool Config::Load(const char *fname)
 	if (GetInt (ifs, "JoystickDeadzone", i))
 		CfgJoystickPrm.Deadzone = max (0, min (10000, i));
 	GetBool (ifs, "IgnoreThrottleOnStart", CfgJoystickPrm.bThrottleIgnore);
+	{
+		double d;
+		if (GetReal (ifs, "JoystickHapticGain", d))
+			CfgJoystickPrm.HapticGain = (float)max (0.0, min (2.0, d));
+	}
 
 	// planet render parameters
 	if (GetInt (ifs, "PlanetPreloadMode", i))
@@ -1303,6 +1309,8 @@ BOOL Config::Write (const char *fname) const
 			ofs << "JoystickDeadzone = " << CfgJoystickPrm.Deadzone << '\n';
 		if (CfgJoystickPrm.bThrottleIgnore != CfgJoystickPrm_default.bThrottleIgnore || bEchoAll)
 			ofs << "IgnoreThrottleOnStart = " << BoolStr (CfgJoystickPrm.bThrottleIgnore) << '\n';
+		if (CfgJoystickPrm.HapticGain != CfgJoystickPrm_default.HapticGain || bEchoAll)
+			ofs << "JoystickHapticGain = " << CfgJoystickPrm.HapticGain << '\n';
 	}
 
 	if (memcmp (&CfgUIPrm, &CfgUIPrm_default, sizeof(CFG_UIPRM)) || bEchoAll) {

--- a/Src/Orbiter/Config.h
+++ b/Src/Orbiter/Config.h
@@ -227,6 +227,7 @@ struct CFG_JOYSTICKPRM {
 	DWORD  ThrottleAxis;		// joystick throttle axis (0=none, 1=z-axis, 2=slider 0, 3=slider 1)
 	int    ThrottleSaturation;	// saturation level for joystick throttle control (0-10000)
 	bool   bThrottleIgnore;		// ignore joystick throttle setting on start
+	float  HapticGain;			// haptic feedback master gain (0=off, 1=default, up to 2)
 };
 
 struct CFG_UIPRM {              // user interface options

--- a/Src/Orbiter/DlgOptions.cpp
+++ b/Src/Orbiter/DlgOptions.cpp
@@ -320,6 +320,11 @@ void DlgOptions::DrawJoystick()
 			g_pOrbiter->OnOptionChanged(OPTCAT_JOYSTICK, OPTITEM_JOYSTICK_PARAM);
 
 	ImGui::EndDisabled();
+
+	ImGui::SeparatorText("Haptic feedback");
+	ImGui::SliderFloat("Rumble gain", &g_pOrbiter->Cfg()->CfgJoystickPrm.HapticGain,
+	                   0.0f, 2.0f, "%.2f");
+	ImGui::TextDisabled("0 disables rumble; 1 is the ship-tuned default.");
 }
 void DlgOptions::DrawCelSphere()
 {

--- a/Src/Orbiter/HapticFX.cpp
+++ b/Src/Orbiter/HapticFX.cpp
@@ -5,6 +5,7 @@
 
 #ifndef _WIN32
 #include <SDL_gamecontroller.h>
+#include <SDL_haptic.h>
 #include <algorithm>
 #include <cmath>
 
@@ -24,9 +25,33 @@ void HapticFX::Bind(SDL_GameController *gc)
 		SDL_GameControllerRumble(m_gc, 0, 0, 0); // stop on detach
 	}
 	m_gc = gc;
+	// The GameController path supersedes the legacy Haptic fallback —
+	// drop any pending fallback binding when a GC becomes available.
+	if (m_gc && m_haptic) m_haptic = nullptr;
 	m_buffetLevel = 0.0f;
 	m_transientLow = m_transientHigh = 0.0f;
 	m_transientLeft = 0.0;
+}
+
+void HapticFX::BindHaptic(SDL_Haptic *haptic)
+{
+	// Only use the legacy fallback when there's no GameController; the
+	// GC path is strictly richer (two independent motors, no need for
+	// the caller to SDL_HapticRumbleInit first).
+	if (m_gc) return;
+	if (m_haptic == haptic) return;
+	if (m_haptic) SDL_HapticRumbleStop(m_haptic);
+	m_haptic = haptic;
+	m_buffetLevel = 0.0f;
+	m_transientLow = m_transientHigh = 0.0f;
+	m_transientLeft = 0.0;
+}
+
+void HapticFX::SetGain(float gain)
+{
+	if (gain < 0.0f) gain = 0.0f;
+	if (gain > 2.0f) gain = 2.0f;
+	m_gain = gain;
 }
 
 static inline Uint16 ScaleAmp(float v01)
@@ -38,7 +63,7 @@ static inline Uint16 ScaleAmp(float v01)
 
 void HapticFX::Tick(double simdt)
 {
-	if (!m_gc) return;
+	if (!m_gc && !m_haptic) return;
 
 	// Decay the transient envelope.
 	if (m_transientLeft > 0.0) {
@@ -52,15 +77,25 @@ void HapticFX::Tick(double simdt)
 	// Mix the channels — buffeting is low frequency, transients ride
 	// on top with the higher-frequency motor. Clamp to 1.0 so the
 	// SDL conversion stays linear and we don't smother the buffet
-	// with a saturating transient.
-	float low  = std::min(1.0f, m_buffetLevel + m_transientLow);
-	float high = std::min(1.0f, m_transientHigh);
+	// with a saturating transient. The master gain scales both
+	// motors equally; 0 disables rumble without disconnecting.
+	float low  = std::min(1.0f, (m_buffetLevel + m_transientLow) * m_gain);
+	float high = std::min(1.0f, m_transientHigh * m_gain);
 
-	// Reapply every frame so the buffet keeps running for as long as
-	// the caller asserts a non-zero level. We use a 200 ms duration
-	// so a missed frame at 60 fps still leaves us with 12 buffer
-	// frames before silence.
-	SDL_GameControllerRumble(m_gc, ScaleAmp(low), ScaleAmp(high), 200);
+	if (m_gc) {
+		// Reapply every frame so the buffet keeps running for as
+		// long as the caller asserts a non-zero level. We use a
+		// 200 ms duration so a missed frame at 60 fps still leaves
+		// us with 12 buffer frames before silence.
+		SDL_GameControllerRumble(m_gc, ScaleAmp(low), ScaleAmp(high), 200);
+	} else {
+		// Legacy SDL_Haptic path: SDL_HapticRumblePlay takes a single
+		// magnitude in [0..1] and a duration. Collapse the two motors
+		// by taking the larger amplitude so transients stay audible
+		// over a sustained buffet.
+		float mag = std::max(low, high);
+		SDL_HapticRumblePlay(m_haptic, mag, 200);
+	}
 }
 
 void HapticFX::Touchdown(float intensity)
@@ -90,6 +125,7 @@ void HapticFX::AtmosphericBuffet(float intensity)
 void HapticFX::Stop()
 {
 	if (m_gc) SDL_GameControllerRumble(m_gc, 0, 0, 0);
+	if (m_haptic) SDL_HapticRumbleStop(m_haptic);
 	m_buffetLevel = 0.0f;
 	m_transientLow = m_transientHigh = 0.0f;
 	m_transientLeft = 0.0;
@@ -108,6 +144,8 @@ namespace orbiter {
 HapticFX::HapticFX() = default;
 HapticFX::~HapticFX() = default;
 void HapticFX::Bind(_SDL_GameController*)        {}
+void HapticFX::BindHaptic(_SDL_Haptic*)          {}
+void HapticFX::SetGain(float)                    {}
 void HapticFX::Tick(double)                       {}
 void HapticFX::Touchdown(float)                  {}
 void HapticFX::EngineIgnite(float)               {}

--- a/Src/Orbiter/HapticFX.h
+++ b/Src/Orbiter/HapticFX.h
@@ -32,6 +32,7 @@
 #include <cstdint>
 
 struct _SDL_GameController;
+struct _SDL_Haptic;
 
 namespace orbiter {
 
@@ -44,6 +45,19 @@ public:
 	// Bind to the SDL_GameController owned by SDLPlatform. nullptr
 	// detaches and stops any running effect. Idempotent.
 	void Bind(_SDL_GameController *gc);
+
+	// Fallback binding for plain SDL_Joystick devices that don't
+	// expose a GameController mapping (older flight sticks). SDLPlatform
+	// opens the haptic interface via SDL_HapticOpenFromJoystick and
+	// initialises SDL_HapticRumble before handing the pointer over.
+	// Ignored if a GameController is already bound.
+	void BindHaptic(_SDL_Haptic *haptic);
+
+	// Master gain multiplier applied to all effects at emit time.
+	// 0 disables rumble entirely; 1 keeps the ship-tuned defaults;
+	// up to 2 for users who want more aggressive feedback. Persisted
+	// in Orbiter.cfg via CfgJoystickPrm.HapticGain.
+	void SetGain(float gain);
 
 	// Per-frame tick: reapplies the sustained AtmosphericBuffet
 	// envelope (SDL_GameControllerRumble durations are bounded, so
@@ -58,15 +72,19 @@ public:
 	void AtmosphericBuffet(float intensity); // 0 stops the channel
 	void Stop();
 
-	bool IsAvailable() const { return m_gc != nullptr; }
+	bool IsAvailable() const { return m_gc != nullptr || m_haptic != nullptr; }
 
 private:
 	_SDL_GameController *m_gc = nullptr;
+	_SDL_Haptic         *m_haptic = nullptr;  // fallback path (legacy joysticks)
 
 	// Mixed-channel state. Each channel contributes a low-freq + a
 	// high-freq amplitude; the per-frame tick combines them and
-	// pushes the result through SDL_GameControllerRumble.
-	float m_buffetLevel = 0.0f;
+	// pushes the result through SDL_GameControllerRumble. The haptic
+	// fallback only exposes a single magnitude, so we collapse the
+	// two motors to max(low, high) before sending it.
+	float m_gain         = 1.0f;
+	float m_buffetLevel  = 0.0f;
 	float m_transientLow = 0.0f;
 	float m_transientHigh = 0.0f;
 	double m_transientLeft = 0.0; // seconds remaining

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -2280,6 +2280,9 @@ void Orbiter::EndTimeStep (bool running)
 	// implementation is a no-op when no controller is attached.
 	if (running && m_pSDL && m_pSDL->GetHaptic() && g_focusobj) {
 		orbiter::HapticFX *fx = m_pSDL->GetHaptic();
+		// Pick up any runtime change to the UI gain slider. SetGain is
+		// cheap (clamp + float assign); no need to gate on change.
+		fx->SetGain(pConfig->CfgJoystickPrm.HapticGain);
 		// Touchdown rising edge.
 		bool contact = g_focusobj->bSurfaceContact;
 		if (contact && !m_haptPrevContact) {

--- a/Src/Orbiter/SDLPlatform.cpp
+++ b/Src/Orbiter/SDLPlatform.cpp
@@ -8,6 +8,8 @@
 #include "SDLPlatform.h"
 #include "HapticFX.h"
 #include "Orbiter.h"
+
+extern Orbiter *g_pOrbiter;
 #include "Log.h"
 #include "imgui.h"
 #include "backends/imgui_impl_sdl2.h"
@@ -308,15 +310,45 @@ bool SDLPlatform::Initialize(int width, int height)
 		}
 	}
 
-	// Bind the haptic channel to the open controller (if any). The
-	// HapticFX wrapper tolerates a null binding so headless / no-pad
+	// Legacy SDL_Joystick fallback — flight sticks and HOTAS without a
+	// SDL_GameController profile still expose rumble through the older
+	// SDL_Haptic API. We only reach here when no GC was claimed above.
+	if (!m_gameController && numJoy > 0) {
+		if (SDL_InitSubSystem(SDL_INIT_HAPTIC) == 0) {
+			for (int i = 0; i < numJoy; i++) {
+				if (SDL_IsGameController(i)) continue;   // already considered
+				SDL_Joystick *js = SDL_JoystickOpen(i);
+				if (!js) continue;
+				SDL_Haptic *h = SDL_HapticOpenFromJoystick(js);
+				if (h && SDL_HapticRumbleSupported(h) && SDL_HapticRumbleInit(h) == 0) {
+					m_joystickLegacy = js;
+					m_hapticLegacy   = h;
+					m_joy.connected  = true;
+					fprintf(stderr, "[SDLPlatform] Legacy joystick haptic: %s\n",
+						SDL_JoystickName(js));
+					break;
+				}
+				if (h) SDL_HapticClose(h);
+				SDL_JoystickClose(js);
+			}
+		}
+	}
+
+	// Bind the haptic channel to whichever device we managed to claim.
+	// The HapticFX wrapper tolerates a null binding so headless / no-pad
 	// runners stay quiet.
 	m_haptic = new HapticFX();
-	m_haptic->Bind(m_gameController);
-	if (m_gameController && SDL_GameControllerHasRumble(m_gameController)) {
-		fprintf(stderr, "[SDLPlatform] Haptic rumble available on %s\n",
-			SDL_GameControllerName(m_gameController));
+	if (m_gameController) {
+		m_haptic->Bind(m_gameController);
+		if (SDL_GameControllerHasRumble(m_gameController))
+			fprintf(stderr, "[SDLPlatform] Haptic rumble available on %s\n",
+				SDL_GameControllerName(m_gameController));
+	} else if (m_hapticLegacy) {
+		m_haptic->BindHaptic(m_hapticLegacy);
 	}
+	// Apply the persisted gain before any effect can fire.
+	if (g_pOrbiter && g_pOrbiter->Cfg())
+		m_haptic->SetGain(g_pOrbiter->Cfg()->CfgJoystickPrm.HapticGain);
 
 	m_initialized = true;
 	return true;
@@ -327,14 +359,23 @@ void SDLPlatform::Shutdown()
 	if (m_haptic) {
 		m_haptic->Stop();
 		m_haptic->Bind(nullptr);
+		m_haptic->BindHaptic(nullptr);
 		delete m_haptic;
 		m_haptic = nullptr;
+	}
+	if (m_hapticLegacy) {
+		SDL_HapticClose(m_hapticLegacy);
+		m_hapticLegacy = nullptr;
+	}
+	if (m_joystickLegacy) {
+		SDL_JoystickClose(m_joystickLegacy);
+		m_joystickLegacy = nullptr;
 	}
 	if (m_gameController) {
 		SDL_GameControllerClose(m_gameController);
 		m_gameController = nullptr;
-		m_joy.connected = false;
 	}
+	m_joy.connected = false;
 	if (m_glContext) {
 		SDL_GL_DeleteContext(m_glContext);
 		m_glContext = nullptr;

--- a/Src/Orbiter/SDLPlatform.h
+++ b/Src/Orbiter/SDLPlatform.h
@@ -117,6 +117,8 @@ private:
 
 	// Joystick
 	SDL_GameController *m_gameController;
+	SDL_Joystick       *m_joystickLegacy = nullptr;  // fallback when no GC mapping
+	SDL_Haptic         *m_hapticLegacy   = nullptr;  // fallback rumble device
 	JoyState m_joy;
 	void UpdateJoystick();
 


### PR DESCRIPTION
## Summary

Two HapticFX follow-ups bundled into one change — they share the same subsystem and the UI for #16 needs the plumbing from #15 to be useful on legacy joysticks.

### #15 — \`SDL_Haptic\` fallback for legacy joysticks

The rumble path was driven exclusively through \`SDL_GameControllerRumble\`, so flight sticks / HOTAS devices without a \`SDL_GameController\` profile never received feedback.

\`SDLPlatform\` now tries \`SDL_HapticOpenFromJoystick\` + \`SDL_HapticRumbleInit\` on every attached device that failed the GameController test, and hands the resulting \`SDL_Haptic\` handle to \`HapticFX::BindHaptic\` when one initialises successfully. The GameController backend is still preferred (two independent motors); the haptic fallback collapses the mixed low/high-frequency channel to \`max(low, high)\` and emits it through \`SDL_HapticRumblePlay\`.

### #16 — User-tunable rumble intensity

Rumble amplitudes were hard-coded in HapticFX, so users on pads too weak or too aggressive had no recourse.

- New \`CFG_JOYSTICKPRM::HapticGain\` (0..2, default 1.0)
- Persisted in \`Orbiter.cfg\` via the \`JoystickHapticGain\` key
- \`HapticFX::SetGain\` applies it at emit time inside \`Tick\`
- Slider exposed in both the Launchpad joystick page and the in-sim \`DlgOptions\` joystick tab (0 disables rumble without unbinding)
- \`Orbiter::UpdateVisual\` pushes the current config value to HapticFX every frame so UI changes take effect without restart

Win32 stubs match the expanded interface (\`BindHaptic\` / \`SetGain\`); nothing changes on the DirectInput path.

## Test plan

- [x] Launchpad → Joystick page: "Rumble gain" slider rendered and interactive
- [x] F6 in-sim → Joystick: same slider appears under a "Haptic feedback" separator
- [x] Change slider value → save scenario → reload: persisted as \`JoystickHapticGain\` in \`Orbiter.cfg\`
- [x] No crash at startup without any joystick or gamepad connected
- [x] \`[SDLPlatform] GameController: …\` log path still taken when a GC-compatible pad is plugged in
- [x] Build clean on \`macos-arm64-debug\`; Win32 stubs compile (header unchanged signature-wise apart from the two new entry points)

## Notes

- The legacy-joystick fallback path is exercised only when a non-GameController device is attached. With no such hardware available here, the code was compile-tested and the GameController path was functionally verified.
- No new \`OPTCAT_\` / \`OPTITEM_\` category added for HapticGain: values are applied directly via per-frame read so no broadcast is needed.

Fixes #15
Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)