### PR TITLE
macos: extend OpenFileIgnoreCase to mesh + celestial-body loaders

### DIFF
--- a/Src/Orbiter/Base.cpp
+++ b/Src/Orbiter/Base.cpp
@@ -48,7 +48,8 @@ Base::Base (char *fname, Planet *_planet, double _lng, double _lat)
 
 	InitDeviceObjects ();
 
-	ifstream ifs (g_pOrbiter->ConfigPath(fname));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->ConfigPath(fname));
 
 	// read location information from file, if available
 	if (ifs && GetItemString (ifs, "LOCATION", cbuf)) {
@@ -200,7 +201,8 @@ void Base::CreateStaticDeviceObjects ()
 {
 	ngenericmesh = 0;
 	ngenerictex  = 0;
-	ifstream ifs (g_pOrbiter->ConfigPath ("Base"));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->ConfigPath ("Base"));
 	if (ifs) {
 		char cbuf[256], **tmp_list;
 		LONGLONG *tmp_id;

--- a/Src/Orbiter/Celbody.cpp
+++ b/Src/Orbiter/Celbody.cpp
@@ -11,6 +11,7 @@
 #define OAPI_IMPLEMENTATION
 
 #include "Orbiter.h"
+#include "Util.h"
 #include "Element.h"
 #include "Celbody.h"
 #include "Log.h"
@@ -48,7 +49,8 @@ CelestialBody::CelestialBody (char *fname)
 	DefaultParam ();
 	ClearModule ();
 
-	ifstream ifs (g_pOrbiter->ConfigPath (fname));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->ConfigPath (fname));
 	if (!ifs) {
 		LOGOUT_ERR_FILENOTFOUND_MSG(g_pOrbiter->ConfigPath (fname), "while initialising celestial body");
 		g_pOrbiter->TerminateOnError();

--- a/Src/Orbiter/Element.cpp
+++ b/Src/Orbiter/Element.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License
 
 #include "Orbiter.h"
+#include "Util.h"
 #include "Element.h"
 #include "Config.h"
 #include <fstream>
@@ -63,7 +64,8 @@ Elements::Elements (const Elements &el)
 Elements::Elements (char *fname)
 {
 	double epoch;
-	ifstream ifs (g_pOrbiter->ConfigPath (fname));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->ConfigPath (fname));
 	if (!GetItemReal (ifs, "Epoch", epoch))           epoch  = 2000.0;
 	mjd_epoch = Jepoch2MJD (epoch);
 	t_epoch   = (mjd_epoch-td.MJD_ref)*86400.0;

--- a/Src/Orbiter/Mesh.cpp
+++ b/Src/Orbiter/Mesh.cpp
@@ -1100,7 +1100,8 @@ const Mesh *MeshManager::LoadMesh (const char *fname, bool *firstload)
 		}
 	}
 	// not found, so load from file
-	ifstream ifs (g_pOrbiter->MeshPath (fname), ios::in);
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->MeshPath (fname), ios::in);
 	Mesh *mesh = new Mesh; TRACENEW
 	ifs >> *mesh;
 	if (!mesh->nGroup()) { // load error
@@ -1133,7 +1134,8 @@ const Mesh *MeshManager::LoadMesh (const char *fname, bool *firstload)
 
 bool LoadMesh (const char *meshname, Mesh &mesh)
 {
-	ifstream ifs (g_pOrbiter->MeshPath (meshname), ios::in);
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->MeshPath (meshname), ios::in);
 	ifs >> mesh;
 	if (ifs.good()) {
 		mesh.SetName(meshname);

--- a/Src/Orbiter/OrbiterAPI.cpp
+++ b/Src/Orbiter/OrbiterAPI.cpp
@@ -1382,7 +1382,8 @@ DLLEXPORT VISHANDLE *oapiObjectVisualPtr (OBJHANDLE hObject)
 
 DLLEXPORT MESHHANDLE oapiLoadMesh (const char *fname)
 {
-	ifstream ifs(g_pOrbiter->MeshPath(fname));
+	ifstream ifs;
+	OpenFileIgnoreCase(ifs, g_pOrbiter->MeshPath(fname));
 	Mesh *mesh = new Mesh; TRACENEW
 	ifs >> *mesh;
 	return (MESHHANDLE)mesh;

--- a/Src/Orbiter/Planet.cpp
+++ b/Src/Orbiter/Planet.cpp
@@ -215,7 +215,8 @@ Planet::Planet (char *fname)
 	maxelev = 0.0;
 	labelLegend  = NULL;
 	nLabelLegend = 0;
-	ifstream ifs (g_pOrbiter->ConfigPath (fname));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->ConfigPath (fname));
 	if (!ifs) return;
 
 	AtmInterface = 0;

--- a/Src/Orbiter/Psys.cpp
+++ b/Src/Orbiter/Psys.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include "Config.h"
+#include "Util.h"
 #include "Psys.h"
 #include "TimeData.h"
 #include "Element.h"
@@ -170,7 +171,8 @@ bool PlanetarySystem::Read (char *fname, const Config* config, OutputLoadStatusC
 	DWORD j;
 	char cbuf[256], label[128];
 	
-	ifstream ifs (config->ConfigPath(fname));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, config->ConfigPath(fname));
 	if (!ifs) return false;
 	Clear();
 	if (GetItemString (ifs, "Name", cbuf)) {

--- a/Src/Orbiter/Rigidbody.cpp
+++ b/Src/Orbiter/Rigidbody.cpp
@@ -14,6 +14,7 @@
 // =======================================================================
 
 #include "Orbiter.h"
+#include "Util.h"
 #include "Rigidbody.h"
 #include "Celbody.h"
 #include "Psys.h"
@@ -62,7 +63,8 @@ RigidBody::RigidBody (double _mass, double _size, const Vector &_pmi): Body (_ma
 RigidBody::RigidBody (char *fname): Body (fname)
 {
 	SetDefaultCaps ();
-	ifstream ifs (g_pOrbiter->ConfigPath (fname));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->ConfigPath (fname));
 	if (ifs) ReadGenericCaps (ifs);
 }
 

--- a/Src/Orbiter/Star.cpp
+++ b/Src/Orbiter/Star.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <stdio.h>
 #include "Orbiter.h"
+#include "Util.h"
 #include "Config.h"
 #include "Star.h"
 #include "Camera.h"
@@ -27,7 +28,8 @@ Star::Star (double _mass, double _mean_radius)
 Star::Star (char *fname)
 : CelestialBody (fname)
 {
-	ifstream ifs (g_pOrbiter->ConfigPath (fname));
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, g_pOrbiter->ConfigPath (fname));
 	if (!ifs) return;
 	bDynamicPosVel = false;
 	// read star-specific parameters here

--- a/Src/Orbiter/Vessel.cpp
+++ b/Src/Orbiter/Vessel.cpp
@@ -438,7 +438,8 @@ void Vessel::ReadGenericCaps (ifstream &ifs)
 
 	// recursively read base class specs
 	if (GetItemString (ifs, "BaseClass", cbuf)) {
-		ifstream basef (g_pOrbiter->ConfigPath (cbuf));
+		ifstream basef;
+		OpenFileIgnoreCase (basef, g_pOrbiter->ConfigPath (cbuf));
 		if (basef) ReadGenericCaps (basef);
 	}
 


### PR DESCRIPTION
## Summary

\`OpenFileIgnoreCase\` (\`Src/Orbiter/Util.cpp\`) already knows how to recover from case mismatches between scenario references and on-disk paths — it walks the path segment by segment and falls back to a \`strcasecmp\` directory scan when the exact name isn't found. But until now only a small handful of call sites (primarily \`Vessel::OpenConfigFile\` and the two \`LoadMesh\` entrypoints in \`Mesh.cpp\`) routed through it. Every other config/mesh opener used a raw \`std::ifstream\`, so references like \`DeltaGlider.msh\` vs on-disk \`Deltaglider.msh\` silently loaded a wireframe fallback on POSIX — Windows' case-insensitive filesystem hides the mismatch entirely.

Route the mesh and vessel/base/celestial-body config opens through \`OpenFileIgnoreCase\`:

| File | Callsite |
|---|---|
| \`Mesh.cpp\` | \`MeshManager::LoadMesh\`, \`LoadMesh\` free function |
| \`OrbiterAPI.cpp\` | \`oapiLoadMesh\` (public SDK) |
| \`Base.cpp\` | \`Base\` ctor, generic-mesh scan |
| \`Vessel.cpp\` | \`BaseClass\` chain |
| \`Celbody.cpp\` | Celbody config |
| \`Planet.cpp\` | Planet config |
| \`Psys.cpp\` | Planetary system config |
| \`Star.cpp\` | Star config |
| \`Element.cpp\` | Orbital-element config |
| \`Rigidbody.cpp\` | Rigidbody config |

## Scope

- Windows is a straight \`ifstream::open\` pass-through (the helper short-circuits on \`_WIN32\`); behaviour there is unchanged.
- Happy-path opens (correctly-cased filenames) are a no-op at runtime — the helper tries the exact path first and only walks segments on failure.
- \`Util.h\` was added to the five files that didn't already include it.

## Out of scope (deliberate)

- **Texture loading** — \`clbkLoadTexture\` normalises backslashes but doesn't case-resolve. A separate helper in \`OGLClient.cpp\` / a generic path-resolution primitive in \`Util.cpp\` would be cleaner than sprinkling \`OpenFileIgnoreCase\` through the texture loaders.
- **Scenario parsing** (\`Scenario.cpp\`, \`Orbiter.cpp LoadScenario\`) — same reasoning.
- **Launchpad / MFD config paths** (\`DlgOptions.cpp\`, \`OptionsPages.cpp\`) — less user-facing and would balloon the diff.

These all deserve a second pass once we have test coverage for case-mismatched references (see the rendering-parity harness work in #14 for the eventual gating mechanism).

## Test plan

- [x] \`cmake --build out/build/macos-arm64-debug --parallel 8\` — clean link, no new warnings
- [x] \`ctest --output-on-failure\` — 3/3 pass (Lua.Interpreter + rendering_parity + example)
- [x] Load a DG + Atlantis scenario interactively; meshes + textures render as before
- [x] No new \`Mesh not found\` log spam

Refs #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)