### PR TITLE
macos: close out OpenFileIgnoreCase audit (#11) + HTML desc browser (#17)

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -7,6 +7,7 @@
 #ifndef _WIN32
 
 #include "OGLClient.h"
+#include "Util.h"  // ResolvePathIgnoreCase
 #include "OGLTexture.h"
 #include "OGLSurface.h"
 #include "OGLShaderMgr.h"
@@ -373,26 +374,28 @@ SURFHANDLE OGLClient::clbkLoadTexture(const char *fname, DWORD flags)
 	std::string normalizedName = fname;
 	for (auto &c : normalizedName) if (c == '\\') c = '/';
 
-	std::string tryPath = m_texturePath + normalizedName;
-	if (FileExists(tryPath.c_str())) {
-		OGLSurface *s = LoadTextureAsSurface(tryPath.c_str());
-		if (s) return (SURFHANDLE)s;
-	}
+	// Each lookup candidate is first probed literally, then via the
+	// case-insensitive resolver so references authored with Win32
+	// casing (e.g. "Atlantis\\MGAtlantis.dds" → "atlantis/mgatlantis.dds"
+	// on disk) resolve on POSIX without a manual rename pass.
+	auto tryLoad = [&](const std::string &path) -> OGLSurface* {
+		if (FileExists(path.c_str()))
+			return LoadTextureAsSurface(path.c_str());
+		const std::string resolved = ResolvePathIgnoreCase(path.c_str());
+		if (!resolved.empty() && resolved != path)
+			return LoadTextureAsSurface(resolved.c_str());
+		return nullptr;
+	};
 
-	if (FileExists(normalizedName.c_str())) {
-		OGLSurface *s = LoadTextureAsSurface(normalizedName.c_str());
-		if (s) return (SURFHANDLE)s;
-	}
+	if (OGLSurface *s = tryLoad(m_texturePath + normalizedName)) return (SURFHANDLE)s;
+	if (OGLSurface *s = tryLoad(normalizedName))                 return (SURFHANDLE)s;
 
 	const char *ext = strrchr(normalizedName.c_str(), '.');
 	if (!ext) {
 		const char *tryExts[] = { ".dds", ".bmp", ".tex", ".png", nullptr };
 		for (int i = 0; tryExts[i]; i++) {
-			std::string tryP = m_texturePath + normalizedName + tryExts[i];
-			if (FileExists(tryP.c_str())) {
-				OGLSurface *s = LoadTextureAsSurface(tryP.c_str());
-				if (s) return (SURFHANDLE)s;
-			}
+			if (OGLSurface *s = tryLoad(m_texturePath + normalizedName + tryExts[i]))
+				return (SURFHANDLE)s;
 		}
 	}
 

--- a/OVP/OGLClient/OGLLaunchpad.cpp
+++ b/OVP/OGLClient/OGLLaunchpad.cpp
@@ -12,6 +12,8 @@
 #include <sys/stat.h>
 #include <algorithm>
 #include <fstream>
+#include <cstdlib>
+#include <unistd.h>
 #include <sstream>
 #include <cstring>
 #include <cstdio>
@@ -387,24 +389,71 @@ std::string OGLLaunchpad::HtmlToPlainText(const std::string &html)
 void OGLLaunchpad::LoadDescription(const std::string &fullPath, bool isFolder)
 {
 	m_selectedDescription.clear();
-	if (isFolder) {
-		// Folders get their description from a sibling Description.txt with the
-		// same DESC / HYPERDESC blocks used by the Windows Launchpad.
-		std::ifstream f(fullPath + "/Description.txt");
-		if (!f.is_open()) return;
-		std::string desc = ScanBlock(f, "DESC");
-		if (desc.empty()) {
-			f.clear();
-			f.seekg(0);
-			std::string hyper = ScanBlock(f, "HYPERDESC");
-			if (!hyper.empty()) desc = HtmlToPlainText(hyper);
-		}
-		m_selectedDescription = desc;
-	} else {
-		std::ifstream f(fullPath);
-		if (!f.is_open()) return;
-		m_selectedDescription = ScanBlock(f, "DESC");
+	m_selectedHyperdesc.clear();
+	const std::string target = isFolder ? fullPath + "/Description.txt" : fullPath;
+	std::ifstream f(target);
+	if (!f.is_open()) return;
+
+	// Capture both blocks so the UI can offer an "Open in browser"
+	// affordance when HYPERDESC is present (Win32 Launchpad renders it
+	// inline via IWebBrowser2 — we have no equivalent on macOS).
+	m_selectedDescription = ScanBlock(f, "DESC");
+	f.clear();
+	f.seekg(0);
+	m_selectedHyperdesc = ScanBlock(f, "HYPERDESC");
+
+	// Folders historically fall back to a plaintext-flattened HYPERDESC
+	// when DESC is absent; keep that behaviour so the summary panel is
+	// never empty.
+	if (isFolder && m_selectedDescription.empty() && !m_selectedHyperdesc.empty())
+		m_selectedDescription = HtmlToPlainText(m_selectedHyperdesc);
+}
+
+void OGLLaunchpad::OpenHyperdescInBrowser()
+{
+	if (m_selectedHyperdesc.empty()) return;
+
+	// Wrap the raw HYPERDESC in a minimal HTML5 document so the
+	// browser has something well-formed to parse — the Orbiter
+	// convention is to include only body markup, no <html>/<head>.
+	const char *tmpl_top =
+		"<!DOCTYPE html>\n"
+		"<html><head><meta charset=\"utf-8\">"
+		"<title>Orbiter scenario description</title>"
+		"<style>body{font-family:-apple-system,Segoe UI,sans-serif;"
+		"max-width:48em;margin:2em auto;padding:0 1em;line-height:1.5}"
+		"h1{font-size:1.4em}</style></head><body>\n";
+	const char *tmpl_bot = "\n</body></html>\n";
+
+	// Write to a per-run temp file. Using /tmp (POSIX) keeps the path
+	// stable enough that repeated clicks overwrite rather than leak.
+	const char *tmpdir = std::getenv("TMPDIR");
+	if (!tmpdir || !*tmpdir) tmpdir = "/tmp";
+	std::string tmpPath = std::string(tmpdir);
+	if (tmpPath.back() != '/') tmpPath += '/';
+	tmpPath += "orbiter_desc.html";
+
+	std::ofstream out(tmpPath, std::ios::binary | std::ios::trunc);
+	if (!out) return;
+	out.write(tmpl_top, (std::streamsize)strlen(tmpl_top));
+	out.write(m_selectedHyperdesc.data(), (std::streamsize)m_selectedHyperdesc.size());
+	out.write(tmpl_bot, (std::streamsize)strlen(tmpl_bot));
+	out.close();
+
+	// Hand the file off to the platform browser. The macOS `open`
+	// command and Linux's `xdg-open` both accept a bare path and
+	// resolve it to file://. fork+exec avoids blocking the GUI.
+#if defined(__APPLE__)
+	const char *cmd = "open";
+#else
+	const char *cmd = "xdg-open";
+#endif
+	pid_t pid = fork();
+	if (pid == 0) {
+		execlp(cmd, cmd, tmpPath.c_str(), (char*)nullptr);
+		_exit(127);
 	}
+	// Parent: don't wait — the browser outlives the Launchpad.
 }
 
 void OGLLaunchpad::ReleaseThumbnail()
@@ -587,6 +636,15 @@ void OGLLaunchpad::RenderTabScenario(float availH)
 			ImGui::TextDisabled("(no description)");
 	} else {
 		ImGui::TextDisabled("Select a scenario to launch - double-click to start immediately.");
+	}
+	// HYPERDESC escape hatch (#17): Win32 renders the block inline via
+	// IWebBrowser2. macOS has no equivalent; a system-browser handoff
+	// keeps the full formatted description reachable without pulling in
+	// WKWebView or an HTML renderer.
+	if (!m_selectedHyperdesc.empty()) {
+		ImGui::Separator();
+		if (ImGui::Button("Open full description in browser"))
+			OpenHyperdescInBrowser();
 	}
 	ImGui::EndChild();
 }

--- a/OVP/OGLClient/OGLLaunchpad.h
+++ b/OVP/OGLClient/OGLLaunchpad.h
@@ -133,6 +133,10 @@ private:
 	std::string m_selectedScenario;
 	std::string m_selectedScenarioFull;
 	std::string m_selectedDescription;
+	// Raw HYPERDESC block (HTML) for the current selection, if any.
+	// Populated alongside m_selectedDescription so the UI can offer an
+	// "Open in browser" button without re-parsing the file.
+	std::string m_selectedHyperdesc;
 	bool m_selectionIsFolder = false;
 	ScenarioThumbnail m_selectedThumb;
 	bool m_startPaused = false;
@@ -164,6 +168,10 @@ private:
 	void ReleaseThumbnail();
 	// Decode HYPERDESC HTML markup into plain text (mirrors Win32 Html2Text).
 	static std::string HtmlToPlainText(const std::string &html);
+	// Write the current selection's HYPERDESC block to a temp HTML file
+	// and hand it to the platform's default browser (`open` on macOS,
+	// `xdg-open` elsewhere). No-op when no HYPERDESC is cached.
+	void OpenHyperdescInBrowser();
 
 	// Parse a sidecar .info file (see cmake/orbiter_module_info.cmake) into
 	// the (category, description) fields of `entry`. Missing file or

--- a/Src/Orbiter/Camera.cpp
+++ b/Src/Orbiter/Camera.cpp
@@ -1307,7 +1307,8 @@ void Camera::InitState (const char *scn, Body *default_target)
 
 	// read state from scenario file
 	if (scn) {
-		ifstream ifs (g_pOrbiter->ScnPath(scn));
+		ifstream ifs;
+		OpenFileIgnoreCase (ifs, g_pOrbiter->ScnPath(scn));
 		if (ifs) Read (ifs);
 	}
 	Body *newtgt = target; target = NULL;

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -1104,7 +1104,8 @@ HWND Orbiter::CreateRenderWindow (Config *pCfg, const char *scenario)
 	for (auto it = m_Plugin.begin(); it != m_Plugin.end(); it++) {
 		void (*opcLoadState)(FILEHANDLE) = (void(*)(FILEHANDLE))FindModuleProc(it->hDLL, "opcLoadState");
 		if (opcLoadState) {
-			ifstream ifs(ScnPath(scenario));
+			ifstream ifs;
+			OpenFileIgnoreCase(ifs, ScnPath(scenario));
 			std::string str = "BEGIN_" + it->sName;
 			if (FindLine(ifs, str.c_str())) {
 				opcLoadState((FILEHANDLE)&ifs);

--- a/Src/Orbiter/State.cpp
+++ b/Src/Orbiter/State.cpp
@@ -41,7 +41,8 @@ void State::Update ()
 
 bool State::Read (const char *fname)
 {
-	ifstream ifs (fname, ios::in);
+	ifstream ifs;
+	OpenFileIgnoreCase (ifs, fname, ios::in);
 	if (!ifs) return false;
 
 	int i;

--- a/Src/Orbiter/Util.cpp
+++ b/Src/Orbiter/Util.cpp
@@ -71,27 +71,25 @@ bool iequal(const std::string& s1, const std::string& s2)
 	return true;
 }
 
-bool OpenFileIgnoreCase(std::ifstream &f, const char *path,
-	std::ios_base::openmode mode)
+std::string ResolvePathIgnoreCase(const char *path)
 {
 #ifdef _WIN32
-	f.open(path, mode);
-	return f.good();
+	return path ? std::string(path) : std::string();
 #else
-	// Fast path: exact match.
-	f.open(path, mode);
-	if (f.good()) return true;
-	f.clear();
+	if (!path || !*path) return std::string();
 
-	// Split into directory + filename, then scan the directory for a
-	// case-insensitive match. Tolerates Win32-style "Vessels\\Foo.cfg"
-	// — the loop walks each path component independently so a
-	// case-mismatch in any segment is recovered.
+	// Fast path: exact match on the given path.
+	{
+		struct stat st;
+		if (stat(path, &st) == 0) return std::string(path);
+	}
+
+	// Walk the path one segment at a time, resolving each to its
+	// canonical (case-corrected) form on disk. Tolerates Win32-style
+	// "Vessels\\Foo.cfg" — path separators are normalised first.
 	std::string p = path;
 	for (auto &c : p) if (c == '\\') c = '/';
 
-	// Walk the path one segment at a time, resolving each to its
-	// canonical (case-corrected) form on disk.
 	std::string resolved;
 	if (!p.empty() && p.front() == '/') resolved = "/";
 	std::string remainder = p;
@@ -115,7 +113,7 @@ bool OpenFileIgnoreCase(std::ifstream &f, const char *path,
 			if (!parent.empty() && parent.back() == '/')
 				parent.pop_back();
 			DIR *d = opendir(parent.empty() ? "/" : parent.c_str());
-			if (!d) return false;
+			if (!d) return std::string();
 			std::string match;
 			struct dirent *e;
 			while ((e = readdir(d)) != nullptr) {
@@ -125,7 +123,7 @@ bool OpenFileIgnoreCase(std::ifstream &f, const char *path,
 				}
 			}
 			closedir(d);
-			if (match.empty()) return false;
+			if (match.empty()) return std::string();
 			resolved = (resolved.empty() ? match : resolved + match);
 		}
 		// Append the trailing slash so the next loop iteration can
@@ -134,6 +132,25 @@ bool OpenFileIgnoreCase(std::ifstream &f, const char *path,
 		remainder = rest;
 	}
 
+	return resolved;
+#endif
+}
+
+bool OpenFileIgnoreCase(std::ifstream &f, const char *path,
+	std::ios_base::openmode mode)
+{
+#ifdef _WIN32
+	f.open(path, mode);
+	return f.good();
+#else
+	// Fast path: exact open — avoids the stat+walk when the file is
+	// already named correctly on disk.
+	f.open(path, mode);
+	if (f.good()) return true;
+	f.clear();
+
+	const std::string resolved = ResolvePathIgnoreCase(path);
+	if (resolved.empty()) return false;
 	f.open(resolved.c_str(), mode);
 	return f.good();
 #endif

--- a/Src/Orbiter/Util.h
+++ b/Src/Orbiter/Util.h
@@ -44,6 +44,12 @@ bool iequal(const std::string& s1, const std::string& s2);
 bool OpenFileIgnoreCase(std::ifstream &f, const char *path,
 	std::ios_base::openmode mode = std::ios_base::in);
 
+// Resolve a path to its case-correct form on disk, walking one segment
+// at a time. Returns an empty string when no case-insensitive match
+// exists at any point along the chain. Windows returns the input path
+// unchanged. Useful for non-ifstream openers (fopen, stbi_load, etc).
+std::string ResolvePathIgnoreCase(const char *path);
+
 // conversion between Vector and VECTOR3 structures
 
 inline Vector MakeVector (const VECTOR3 &v)


### PR DESCRIPTION
## Summary

Two loose ends closed in one small PR.

### #11 — extend \`OpenFileIgnoreCase\` to texture and scenario loaders

The previous pass (#100) routed mesh and celestial-body config opens through the helper but left texture loading and the scenario file parser on raw \`ifstream\` / \`fopen\`. Same latent bug: a scenario that references \`Atlantis\\MGAtlantis.dds\` silently drops the texture on POSIX if disk has it at \`atlantis/mgatlantis.dds\`.

- Split the case-insensitive directory-walk out of \`OpenFileIgnoreCase\` into a reusable \`ResolvePathIgnoreCase(const char *)\` that returns a resolved path string, so non-ifstream openers (\`fopen\`, \`LoadTextureAsSurface\`) can benefit without duplicating the walk.
- \`OGLClient::clbkLoadTexture\` now probes each candidate path with \`ResolvePathIgnoreCase\` as a fallback. Happy-path exact matches stay on the fast \`stat\`-only check.
- \`State::Read\`, \`Camera\` scenario restore, and the plugin \`opcLoadState\` hook all read the \`.scn\` through \`OpenFileIgnoreCase\` so a scenario passed on the CLI with mismatched case still loads.

### #17 — "Open full description in browser" button

Win32's Launchpad renders scenario \`HYPERDESC\` HTML inline via an \`IWebBrowser2\` control; macOS had no equivalent and was downgraded to plain text. Option 3 from the issue body:

- \`OGLLaunchpad\` caches the raw \`HYPERDESC\` alongside the flattened \`DESC\` when loading a scenario/folder.
- Whenever the cache is non-empty, the right pane shows an **Open full description in browser** button.
- Clicking writes a minimal HTML5 wrapper around the \`HYPERDESC\` body to \`/tmp/orbiter_desc.html\` and hands it to \`open\` (macOS) / \`xdg-open\` (Linux) via \`fork\` + \`exec\`. No WKWebView / AppKit dependency.

Plain-text \`DESC\` flow is unchanged; the button doesn't appear when no \`HYPERDESC\` is present.

## Test plan

- [x] Build clean on \`macos-arm64-debug\`
- [x] Launchpad → navigate into a folder with \`BEGIN_HYPERDESC\` (e.g. \`Demo/\`): button appears; clicking opens the default browser with the formatted description
- [x] Folders / scenarios without \`HYPERDESC\`: no button (plain \`DESC\` still renders)
- [x] Load DG / Atlantis scenario interactively — vessel + textures unchanged (\`clbkLoadTexture\` happy-path unaffected)
- [x] CLI launch with a case-mismatched scenario name: scenario now resolves instead of failing

Fixes #11
Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)