### PR TITLE
macos: modulate matEmissive by albedo so VC textures read properly

### DIFF
--- a/OVP/OGLClient/shaders/vessel.frag
+++ b/OVP/OGLClient/shaders/vessel.frag
@@ -15,6 +15,9 @@ void main() {
     if (matHasDiffuse != 0) {
         baseColor *= texture(uTexture, vUV);
     }
-    vec3 lit = baseColor.rgb * vLight + matEmissive.rgb;
+    // matEmissive is modulated by baseColor to mirror D3D9's pattern
+    // `cTex *= saturate(diff + emissive)` — authoring expected emissive
+    // to scale with the diffuse texture, not override it (issue #101).
+    vec3 lit = baseColor.rgb * (vLight + matEmissive.rgb);
     FragColor = vec4(lit, baseColor.a);
 }

--- a/OVP/OGLClient/shaders/vessel_pbr.frag
+++ b/OVP/OGLClient/shaders/vessel_pbr.frag
@@ -71,8 +71,22 @@ void main() {
     if (matHasMetalness != 0) metalness = texture(uMetalnessTex, vUV).g;
     metalness = clamp(metalness, 0.0, 1.0);
 
-    vec3 emission = matEmissive.rgb;
-    if (matHasEmissive != 0) emission = texture(uEmissiveTex, vUV).rgb;
+    // Emissive has two distinct sources:
+    //   - an emissive *texture* (matHasEmissive == 1) is a per-texel
+    //     radiance map and is added as-is;
+    //   - matEmissive as a *material* property is a D3D-era "always-on"
+    //     lighting boost the authoring expected to be multiplied by the
+    //     diffuse texture (see D3D9Client/Shaders/PBR.fx:475 —
+    //     `cDiff *= saturate(... + gMtrl.emissive.rgb)`). Without the
+    //     albedo modulation the DeltaGlider VC (whose materials ship
+    //     emissive=0.8 for most panels) washes out to flat grey because
+    //     every fragment gets a +0.8 bias regardless of texture detail
+    //     (issue #101).
+    vec3 emission;
+    if (matHasEmissive != 0)
+        emission = texture(uEmissiveTex, vUV).rgb;
+    else
+        emission = matEmissive.rgb * albedo.rgb;
 
     vec3 F0 = materialF0(albedo.rgb);
 


### PR DESCRIPTION
## Summary

The DeltaGlider's virtual cockpit (and, to a lesser extent, every other vessel interior) rendered as a nearly uniform light-grey wash on macOS. Texture binding was correct — a debug pass that emitted the raw sampled texel showed every panel, button, astronaut suit, and label in full detail — but the lit output collapsed them back to flat grey.

## Root cause

DG VC materials ship with emissive in the 0.6..1.0 range (\`LIT_BUTTON\` = 0.6, most panels = 0.8, \`inst1_6\` = 1.0) — the D3D-era convention where "self-lit" cockpit parts stay readable when the sun is on the wrong side of the hull. Our fragment shader added \`matEmissive.rgb\` to the final colour as an *independent* radiance term, so a surface with emissive=0.8 picked up a flat +0.8 bias regardless of the diffuse texture's detail, washing everything out after the Reinhard compression.

## D3D9 reference

\`D3D9Client/Shaders/PBR.fx:475\` mirrors the legacy \`Mesh.fx\` path:

\`\`\`hlsl
cDiff.rgb *= saturate( gMtrl.diffuse.rgb*(dLN*cSun + cDiffLocal)
                     + gMtrl.ambient.rgb*gSun.Ambient
                     + gMtrl.emissive.rgb );
\`\`\`

Emissive is part of the lighting factor the diffuse texture is *multiplied by*, not an additive overlay on top.

## Fix

Modulate the material's emissive contribution by albedo (\`matDiffuse * texture\`) when no dedicated emissive texture is present:

- \`vessel_pbr.frag\`: \`emission = matEmissive.rgb * albedo.rgb\` (material path). Emissive *textures* (\`matHasEmissive != 0\`) stay additive-as-is — they're already per-texel radiance maps.
- \`vessel.frag\` (legacy): same change, folded into the combined \`vLight + matEmissive\` factor that multiplies \`baseColor\`.

## Test plan

- [x] DG VC: panels, buttons, astronaut suits, labels, MFDs all legible
- [x] DG external: unchanged (external materials have emissive ≈ 0 so the fix is a no-op there)
- [x] Atlantis external: unchanged
- [x] Shuttle-A: unchanged
- [x] Build clean on \`macos-arm64-debug\`

## Out of scope

The remaining magenta / untextured parts of the VC screenshot (helmet visors) are materials without a diffuse texture and with emissive=0.8 — they fall through the \`matHasDiffuse == 0\` branch. Intentional per the asset; not a regression.

Fixes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)