### PR TITLE
macos: animate exhaust flames + add flare halo around the nozzle

### DIFF
--- a/OVP/OGLClient/OGLvVessel.cpp
+++ b/OVP/OGLClient/OGLvVessel.cpp
@@ -329,14 +329,28 @@ void OGLvVessel::InitShared(ShaderMgr *shaderMgr, const std::string &texturePath
 	if (FileExists(path.c_str()))
 		s_exhaustTexture = OGLTexture::LoadDDS(path.c_str());
 
-	// Create exhaust billboard quad (vertices updated per-exhaust)
+	// Exhaust billboard geometry (positions filled per-exhaust, per-frame).
+	// Two quads:
+	//   vtx 0..3 — core cone (narrow at the tip, sits on the plume axis)
+	//   vtx 4..7 — flare halo (larger camera-aligned quad centred at the
+	//              nozzle), gives the "bright bulb" look Windows ships
+	//              (see D3D9Client/D3D9Effect.cpp:778-816).
+	// UV atlas: core sits in the left strip of Exhaust.dds (U 0.01..0.24),
+	// flare in the upper-right region (U 0.50..1.00, V 0..0.50).
 	float verts[] = {
-		0,0,0, 0.24f,0,
-		0,0,0, 0.24f,1,
-		0,0,0, 0.01f,0,
-		0,0,0, 0.01f,1,
+		0,0,0, 0.24f, 0.0f,
+		0,0,0, 0.24f, 1.0f,
+		0,0,0, 0.01f, 0.0f,
+		0,0,0, 0.01f, 1.0f,
+		0,0,0, 0.50390625f, 0.00390625f,
+		0,0,0, 0.99609375f, 0.00390625f,
+		0,0,0, 0.50390625f, 0.49609375f,
+		0,0,0, 0.99609375f, 0.49609375f,
 	};
-	unsigned int idx[] = {0,1,2, 3,2,1};
+	unsigned int idx[] = {
+		0,1,2,  3,2,1,     // core
+		4,5,6,  7,6,5,     // flare
+	};
 
 	glGenVertexArrays(1, &s_exhaustVAO);
 	glGenBuffers(1, &s_exhaustVBO);
@@ -815,6 +829,13 @@ void OGLvVessel::RenderExhausts(VESSEL *vessel, const MATRIX3 &vrot,
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, s_exhaustTexture->texId);
 	glUniform1i(s_shaderMgr->GetUniformLoc(s_exhaustShader, "uTexture"), 0);
+	// Animated flicker (issue #102): the shader modulates brightness and
+	// alpha by a mix of a sinusoid and cheap UV turbulence; we feed it the
+	// sim time + a per-thruster phase so engines don't pulse in lockstep.
+	const float simTime = (float)oapiGetSimTime();
+	const GLint uTimeLoc  = s_shaderMgr->GetUniformLoc(s_exhaustShader, "uTime");
+	const GLint uPhaseLoc = s_shaderMgr->GetUniformLoc(s_exhaustShader, "uPhase");
+	glUniform1f(uTimeLoc, simTime);
 
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_ONE, GL_ONE);
@@ -831,36 +852,73 @@ void OGLvVessel::RenderExhausts(VESSEL *vessel, const MATRIX3 &vrot,
 		if (!vessel->GetExhaustSpec(i, &es)) continue;
 		if (!es.lpos || !es.ldir) continue;
 
-		float lsz = (float)(es.lsize * level * scale);
+		// Per-thruster phase + length jitter. The phase is a deterministic
+		// hash of the index so a given engine always animates the same way
+		// frame to frame; the length wobble rides on a slow ~3 Hz sine so
+		// the plume feels like it's breathing rather than just blinking.
+		const float phase = (float)i * 2.3987f;
+		const float jitter = 1.0f + 0.06f * sinf(simTime * 3.0f + phase);
+		glUniform1f(uPhaseLoc, phase);
+
+		float lsz = (float)(es.lsize * level * scale) * jitter;
 		float wsz = (float)(es.wsize * level * scale);
 		if (lsz < 0.001f) continue;
 
+		// Plume origin (lpos, offset back by lofs along the exhaust
+		// direction to match D3D9's `ref = lpos - ldir*lofs`).
 		VECTOR3 lp = *es.lpos, ld = *es.ldir;
-		float ex = (float)(vrot.m11 * lp.x + vrot.m12 * lp.y + vrot.m13 * lp.z) * scale + tx;
-		float ey = (float)(vrot.m21 * lp.x + vrot.m22 * lp.y + vrot.m23 * lp.z) * scale + ty;
-		float ez = (float)(vrot.m31 * lp.x + vrot.m32 * lp.y + vrot.m33 * lp.z) * scale + tz;
+		VECTOR3 refLocal = {
+			lp.x - ld.x * es.lofs,
+			lp.y - ld.y * es.lofs,
+			lp.z - ld.z * es.lofs
+		};
+		float ex = (float)(vrot.m11 * refLocal.x + vrot.m12 * refLocal.y + vrot.m13 * refLocal.z) * scale + tx;
+		float ey = (float)(vrot.m21 * refLocal.x + vrot.m22 * refLocal.y + vrot.m23 * refLocal.z) * scale + ty;
+		float ez = (float)(vrot.m31 * refLocal.x + vrot.m32 * refLocal.y + vrot.m33 * refLocal.z) * scale + tz;
+		// Exhaust direction in world (edir = -ldir, normalised).
 		float dx = -(float)(vrot.m11 * ld.x + vrot.m12 * ld.y + vrot.m13 * ld.z);
 		float dy = -(float)(vrot.m21 * ld.x + vrot.m22 * ld.y + vrot.m23 * ld.z);
 		float dz = -(float)(vrot.m31 * ld.x + vrot.m32 * ld.y + vrot.m33 * ld.z);
 
+		// sdir = camera × exhaust (perpendicular to both, used to
+		// fatten the core quad) — normalised.
 		float sx = cdy * dz - cdz * dy, sy = cdz * dx - cdx * dz, sz = cdx * dy - cdy * dx;
 		float slen = sqrtf(sx * sx + sy * sy + sz * sz);
 		if (slen < 1e-6f) { sx = 1; sy = 0; sz = 0; slen = 1; }
 		sx /= slen; sy /= slen; sz /= slen;
 
-		float hw = wsz * 0.5f;
+		// tdir = camera × sdir. Camera-aligned, used to build the flare
+		// quad so it always faces the viewer.
+		float ttx = cdy * sz - cdz * sy;
+		float tty = cdz * sx - cdx * sz;
+		float ttz = cdx * sy - cdy * sx;
+		float tlen = sqrtf(ttx*ttx + tty*tty + ttz*ttz);
+		if (tlen > 1e-6f) { ttx /= tlen; tty /= tlen; ttz /= tlen; }
+
+		const float hw        = wsz * 0.5f;
+		// D3D9 uses flarescale = 7; scale the same way but only to half
+		// because our hw is already half-width.
+		const float flare     = wsz * 3.5f;
+
 		float verts[] = {
-			ex - sx * hw, ey - sy * hw, ez - sz * hw, 0.24f, 0.0f,
-			ex + sx * hw, ey + sy * hw, ez + sz * hw, 0.24f, 1.0f,
+			// Core quad — same narrow cone as before.
+			ex - sx * hw,             ey - sy * hw,             ez - sz * hw,             0.24f, 0.0f,
+			ex + sx * hw,             ey + sy * hw,             ez + sz * hw,             0.24f, 1.0f,
 			ex + dx * lsz - sx * hw * 0.2f, ey + dy * lsz - sy * hw * 0.2f, ez + dz * lsz - sz * hw * 0.2f, 0.01f, 0.0f,
 			ex + dx * lsz + sx * hw * 0.2f, ey + dy * lsz + sy * hw * 0.2f, ez + dz * lsz + sz * hw * 0.2f, 0.01f, 1.0f,
+			// Flare halo — camera-aligned quad centred at the nozzle,
+			// 7× wide to match D3D9Client's bloom halo.
+			ex - sx * flare + ttx * flare, ey - sy * flare + tty * flare, ez - sz * flare + ttz * flare, 0.50390625f, 0.00390625f,
+			ex + sx * flare + ttx * flare, ey + sy * flare + tty * flare, ez + sz * flare + ttz * flare, 0.99609375f, 0.00390625f,
+			ex - sx * flare - ttx * flare, ey - sy * flare - tty * flare, ez - sz * flare - ttz * flare, 0.50390625f, 0.49609375f,
+			ex + sx * flare - ttx * flare, ey + sy * flare - tty * flare, ez + sz * flare - ttz * flare, 0.99609375f, 0.49609375f,
 		};
 
 		glBindVertexArray(s_exhaustVAO);
 		glBindBuffer(GL_ARRAY_BUFFER, s_exhaustVBO);
 		glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(verts), verts);
 		glUniform1f(s_shaderMgr->GetUniformLoc(s_exhaustShader, "uAlpha"), (float)level);
-		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+		glDrawElements(GL_TRIANGLES, 12, GL_UNSIGNED_INT, 0);
 	}
 
 	glBindVertexArray(0);

--- a/OVP/OGLClient/shaders/exhaust.frag
+++ b/OVP/OGLClient/shaders/exhaust.frag
@@ -9,25 +9,65 @@ in vec2 vUV;
 
 uniform sampler2D uTexture;
 uniform float     uAlpha;
+uniform float     uTime;   // seconds, drives the animated flicker
+uniform float     uPhase;  // per-thruster phase offset so engines don't pulse in unison
 
 out vec4 FragColor;
+
+// Cheap hash-based noise, UV-seeded, for per-fragment turbulence.
+float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+}
 
 void main() {
     vec4 tex = texture(uTexture, vUV);
 
-    // Inner (hot white) vs outer (warm yellow) core — U runs 0..1 along
-    // the plume axis in texture space, roughly 0=tail, 1=nozzle.
-    vec3 inner = vec3(1.00, 0.96, 0.85);
-    vec3 outer = vec3(1.00, 0.55, 0.18);
-    float coreT = smoothstep(0.05, 0.24, vUV.x);
-    vec3  ramp  = mix(outer, inner, coreT);
+    // Combined brightness flicker: a smooth ~20 Hz sinusoid plus a small
+    // amount of UV-seeded turbulence scrolled along the plume axis. Keeps
+    // the plume alive without looking stroboscopic.
+    float pulse = 0.90 + 0.10 * sin(uTime * 22.0 + uPhase);
+    float turb  = 0.95 + 0.10 * hash(vec2(vUV.y * 7.0, vUV.x * 3.0 + uTime * 4.0));
+    float flicker = pulse * turb;
 
-    // Soft V-edge falloff so the quad fades to zero at the flank instead
-    // of clipping to rectangular silhouette.
-    float vEdge = 1.0 - abs(vUV.y - 0.5) * 2.0;
-    vEdge = smoothstep(0.0, 0.35, vEdge);
+    // Atlas layout (shared with D3D9Client/D3D9Effect.cpp): the left
+    // strip U < ~0.25 is the core plume gradient, the upper-right
+    // quadrant U > ~0.5 is reserved for the flare/halo glow. Some
+    // Exhaust.dds atlases don't actually ship a pre-baked halo in
+    // that quadrant, so the flare branch synthesises the radial
+    // falloff analytically from the atlas UVs rather than trusting
+    // the texel alpha — any leftover texel that happens to be white
+    // would otherwise show as a hard-edged rectangle around the
+    // nozzle.
+    vec3 col;
+    float outAlpha;
+    if (vUV.x > 0.4) {
+        // Remap flare-quadrant UVs to a local 0..1 space, build a
+        // soft radial mask (1 at centre, 0 at corners) and blend
+        // toward the hot-core colour so the halo reads as the same
+        // temperature as the plume it envelops.
+        vec2 flareUV = (vUV - vec2(0.504, 0.004)) / vec2(0.492, 0.492);
+        float r = length(flareUV - vec2(0.5)) * 2.0;        // 0..√2
+        float mask = 1.0 - smoothstep(0.0, 1.0, r);         // cubic-like falloff
+        vec3  inner = vec3(1.00, 0.96, 0.85);
+        col = inner * mask * flicker;
+        outAlpha = mask * uAlpha * flicker * 0.55;          // halo softer than core
+    } else {
+        // Inner (hot white) vs outer (warm yellow) core — U runs 0..1
+        // along the plume axis in texture space, roughly 0=tail, 1=nozzle.
+        vec3 inner = vec3(1.00, 0.96, 0.85);
+        vec3 outer = vec3(1.00, 0.55, 0.18);
+        float coreT = smoothstep(0.05, 0.24, vUV.x);
+        vec3  ramp  = mix(outer, inner, coreT);
 
-    vec3 col = tex.rgb * ramp * vEdge;
+        // Soft V-edge falloff so the quad fades to zero at the flank
+        // instead of clipping to rectangular silhouette.
+        float vEdge = 1.0 - abs(vUV.y - 0.5) * 2.0;
+        vEdge = smoothstep(0.0, 0.35, vEdge);
+
+        col = tex.rgb * ramp * vEdge * flicker;
+        outAlpha = tex.a * uAlpha * flicker;
+    }
+
     // Additive blending upstream (GL_ONE, GL_ONE).
-    FragColor = vec4(col * uAlpha, tex.a * uAlpha);
+    FragColor = vec4(col * uAlpha, outAlpha);
 }


### PR DESCRIPTION
## Summary

The exhaust plume rendered as a static textured quad per thruster — no flicker, no intensity wobble, no glow halo — so the DG at full throttle looked like a printed sticker next to the Windows reference. Two changes bring the OpenGL render close to parity with \`D3D9Client\`:

### Animated flicker

Every frame:
- Sim time + a per-thruster phase offset are passed into the exhaust shader.
- Shader combines a smooth 22 Hz sinusoid with cheap UV-seeded turbulence scrolled along the plume axis. The product modulates both the plume colour and the alpha — brightness breathes and flickers without pulsing stroboscopically.
- CPU side: length jitter (±6 % sine at ~3 Hz, per-thruster phase) so the visible plume length breathes too, not just its brightness.

### Flare halo around the nozzle

\`D3D9Client\` draws two quads per thruster: the narrow plume cone plus a camera-aligned "flare" quad scaled 7× in width (\`D3D9Effect.cpp:786\` \`flarescale\`). That's the bright bulb you see around every nozzle on the Windows build. We now match:

- VBO extended from 4 to 8 vertices; IBO from 6 to 12 indices.
- Flare vertices placed on a plane perpendicular to the camera direction (using the \`tdir = camera × sdir\` basis) so the halo always faces the viewer.
- The texture atlas slot reserved for the flare (U 0.50..1.00, V 0.00..0.50) is not guaranteed to ship a baked radial image — Orbiter's bundled \`Exhaust.dds\` in particular leaves that region mostly white. The fragment shader synthesises the radial falloff analytically from the atlas UVs rather than trusting texel alpha, so we don't get a hard-edged rectangle around the nozzle.

Also fold in the existing \`lpos - ldir*lofs\` offset that D3D9 applies to the plume origin — previously we anchored the cone at \`lpos\` flat, slightly off from the authored nozzle position.

## Before / after

Before: flat billboard, no halo.
After: breathing core + soft white halo. Interactively verified on DG at full thrust.

## Scope note

The long vapor trail seen behind thrusting vessels on Windows (visible in the reference screenshot for this issue) is a separate subsystem — \`oapiCreateParticleStream\` — that feeds particles into a spawner / emitter / mesh chain. This PR closes the flame-itself gap; the trail is tracked in a follow-up issue.

## Test plan

- [x] DG full thrust (space + atmosphere): core flickers, halo visible, scales with throttle
- [x] Multiple engines (DG, Shuttle-A hover): each engine's flicker is phase-offset so they don't pulse in lockstep
- [x] Level ≈ 0 (idle): no visible plume, no halo — alpha scales to 0 cleanly
- [x] No regressions on non-thrust rendering
- [x] Build clean on \`macos-arm64-debug\`

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)