### PR TITLE
macos: implement SendKbdBuffered on POSIX + fix LuaInline XRSound-off dlopen failures

### DIFF
--- a/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
+++ b/Src/Module/LuaScript/LuaInterpreter/Interpreter.cpp
@@ -133,6 +133,15 @@ void Interpreter::Initialise ()
 	LoadStartupScript (); // load default initialisation script
 }
 
+#ifndef XRSOUND
+// Stub when the XRSound lua module isn't built — lua_xrsound.cpp owns the
+// real implementation but is only compiled under ORBITER_BUILD_XRSOUND.
+// Without this no-op, dlopen'ing LuaInline / LuaMFD / LuaConsole fails at
+// runtime with "symbol not found: Interpreter::LoadXRSoundAPI()" and every
+// scenario `Script = ...` directive silently never runs.
+void Interpreter::LoadXRSoundAPI () {}
+#endif
+
 int Interpreter::Status () const
 {
 	return status;
@@ -736,6 +745,7 @@ int Interpreter::RunChunk (const char *chunk, int n)
 		if (res) {
 			auto error = lua_tostring(L, -1);
 			if (error) { // can be nullptr
+				fprintf(stderr, "[Lua error] %s\n", error);
 				if (is_term) {
 					// term_strout ("Execution error.");
 					term_strout(error, true);
@@ -1085,12 +1095,18 @@ void Interpreter::LoadAPI ()
 	};
 	luaL_openlib (L, "term", termLib, 0);
 
-	// Load XRSound library
+	// Load XRSound library only when the XRSound API is compiled in —
+	// lua_xrsound.cpp owns the implementation, and building without
+	// ORBITER_BUILD_XRSOUND leaves `xrsound_create_instance` unresolved.
+	// Referencing it here would be a dangling symbol that fails dlopen on
+	// every downstream Lua module (LuaInline, LuaMFD, LuaConsole).
+#ifdef XRSOUND
 	static const struct luaL_reg XRSoundLib[] = {
 		{"create_instance", xrsound_create_instance},
 		{NULL, NULL}
 	};
 	luaL_openlib (L, "xrsound", XRSoundLib, 0);
+#endif
 
 	// Set up global tables of constants
 

--- a/Src/Orbiter/Orbiter.cpp
+++ b/Src/Orbiter/Orbiter.cpp
@@ -2668,9 +2668,18 @@ HRESULT Orbiter::UserInput ()
 	return S_OK;
 }
 
+// End of Win32-specific UserInput() — the following buffered/immediate
+// keyboard dispatchers are cross-platform (they synthesise DIDEVICEOBJECTDATA
+// records in the shared format that Orbiter's dispatch path already consumes).
+#endif // _WIN32 -- UserInput
+
 //-----------------------------------------------------------------------------
 // Name: SendKbdBuffered()
-// Desc: Simulate a buffered keyboard event
+// Desc: Simulate a buffered keyboard event. Lives outside the _WIN32 branch
+//       because `oapi.simulatebufferedkey` (Lua) and `oapiSimulateBufferedKey`
+//       (plugins) need to synthesise events on every platform — the previous
+//       macOS stub in platform_stubs_posix.cpp returned false and silently
+//       swallowed every scripted keystroke (fixes #110).
 //-----------------------------------------------------------------------------
 
 bool Orbiter::SendKbdBuffered(DWORD key, DWORD *mod, DWORD nmod, bool onRunningOnly)
@@ -2703,10 +2712,6 @@ bool Orbiter::SendKbdImmediate(char kstate[256], bool onRunningOnly)
 	bAllowInput = true; // make sure the render window processes inputs
 	return true;
 }
-
-// End of Win32-specific buffered input methods. The following immediate
-// keyboard handlers are cross-platform (they just read the kstate array).
-#endif // _WIN32 -- SendKbdBuffered, SendKbdImmediate
 
 //-----------------------------------------------------------------------------
 // Name: KbdInputImmediate_System ()

--- a/Src/Orbiter/platform_stubs_posix.cpp
+++ b/Src/Orbiter/platform_stubs_posix.cpp
@@ -69,10 +69,9 @@ void ConsoleNG::EchoIntro() const {}
 // ======================================================================
 
 // MouseEvent, BroadcastMouseEvent, BroadcastImmediateKeyboardEvent,
-// BroadcastBufferedKeyboardEvent, KbdInputBuffered_System/OnRunning are now
-// compiled from Orbiter.cpp for all platforms (no longer Windows-only).
-bool Orbiter::SendKbdBuffered(DWORD, DWORD*, DWORD, bool) { return false; }
-bool Orbiter::SendKbdImmediate(char[256], bool) { return false; }
+// BroadcastBufferedKeyboardEvent, KbdInputBuffered_System/OnRunning,
+// SendKbdBuffered, SendKbdImmediate are now compiled from Orbiter.cpp for
+// all platforms (no longer Windows-only).
 
 // MemStat is compiled from Memstat.cpp - no stub needed
 


### PR DESCRIPTION
## Summary

Fixes [#110](https://github.com/kanik0/orbiter/issues/110). `oapi.simulatebufferedkey` was a no-op on macOS because `Src/Orbiter/platform_stubs_posix.cpp` provided a stub `Orbiter::SendKbdBuffered` that returned `false`. The real Win32 implementation lived inside a `#ifdef _WIN32` branch in `Orbiter.cpp`, so every scenario script that tried to synthesise a keystroke (Demo/Atlantis Ascent AP's `Shift+L` to arm the shuttle AP, DG demos that stage keystrokes, etc.) silently did nothing.

This PR:

- Moves `SendKbdBuffered` and `SendKbdImmediate` out of the `_WIN32` branch in `Src/Orbiter/Orbiter.cpp`. They only call cross-platform helpers (`BroadcastBufferedKeyboardEvent`, `KbdInputBuffered_System`, `KbdInputBuffered_OnRunning`), all of which were already made cross-platform in an earlier pass.
- Drops the POSIX stubs in `Src/Orbiter/platform_stubs_posix.cpp`.
- Fixes two collateral bugs that kept `libLuaInline.dylib / libLuaMFD.dylib / libLuaConsole.dylib` from dlopening at all on an `ORBITER_BUILD_XRSOUND=OFF` build — surfaced while chasing why the Lua script path wasn't firing in the first place:
  - `Interpreter::LoadXRSoundAPI()` is declared in `Interpreter.h` and called unconditionally from `Initialise()`, but only defined in `lua_xrsound.cpp` which CMake only compiles when XRSound is ON. Added an inline no-op stub under `#ifndef XRSOUND` in `Interpreter.cpp`.
  - `Interpreter::LoadAPI` always registered `xrsound.create_instance` via `luaL_openlib`, pulling `Interpreter::xrsound_create_instance` in as another dangling undefined. Guarded the registration with `#ifdef XRSOUND`.
- Surfaces Lua runtime errors on stderr (previously only shown when a terminal was attached), so the next silent failure in this area is a `grep "Lua error"` away.

## Test plan

- [x] Demo/Atlantis Ascent AP launches without any mouse input: the Lua script reaches the `Shift+L` keystroke at ~90 s of real time and the shuttle lifts off, matching the Windows behaviour.
- [x] Fresh `cmake --build ... --target Orbiter` produces a binary where `LuaInline`, `LuaMFD`, `LuaConsole` all dlopen successfully on `ORBITER_BUILD_XRSOUND=OFF`.
- [x] No regression on `ORBITER_BUILD_XRSOUND=ON` builds — the `#ifdef XRSOUND` branches are the original code.
- [ ] CI macOS green on both XRSound ON and OFF configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)