### PR TITLE
macos: fallback mesh lookup uses mesh name, not class name

### DIFF
--- a/OVP/OGLClient/OGLvVessel.cpp
+++ b/OVP/OGLClient/OGLvVessel.cpp
@@ -550,11 +550,15 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 			if (!ShouldRenderMesh(vismode, /*internalpass=*/false, /*bCockpit=*/false, /*bVC=*/false))
 				continue;
 
+			// Same fallback as the main pass — look up the cache by the stored
+			// mesh name, not the vessel class name. The shadow pass only reads
+			// (never populates) the cache so a missing entry just skips the
+			// shadow for this frame.
 			MESHHANDLE hMesh = vessel->GetMeshTemplate(m);
 			if (!hMesh) {
-				const char *className = vessel->GetClassName();
-				if (className) {
-					auto it = s_fallbackMeshes.find(className);
+				const char *meshName = vessel->GetMeshName(m);
+				if (meshName && *meshName) {
+					auto it = s_fallbackMeshes.find(meshName);
 					if (it != s_fallbackMeshes.end()) hMesh = it->second;
 				}
 			}
@@ -650,18 +654,26 @@ void OGLvVessel::Render(const float *vp, const VECTOR3 &camPos, const VECTOR3 &s
 		WORD vismode = vessel->GetMeshVisibilityMode(m);
 		if (!ShouldRenderMesh(vismode, internalpass, bCockpit, bVC)) continue;
 
+		// AddMesh(hMesh, ...) stores the preloaded handle, but AddMesh(name, ofs)
+		// leaves `hMesh = NULL` and keeps only the filename. The D3D9 client
+		// calls `CopyMeshFromTemplate` in that case (VVessel.cpp:298) which
+		// loads from `meshname`. Previously we fell back to
+		// `oapiLoadMeshGlobal(vessel->GetClassName())` — but the class name
+		// has nothing to do with the missing mesh slot, so on every Atlantis
+		// mission the optional `shuttle_eva_plat` / cargo slot re-loaded the
+		// orbiter mesh and rendered it at the platform offset, producing a
+		// second shuttle hovering next to the real one. Use the stored mesh
+		// name instead; fall through and skip when both are missing.
 		MESHHANDLE hMesh = vessel->GetMeshTemplate(m);
 		if (!hMesh) {
-			const char *className = vessel->GetClassName();
-			if (className) {
-				auto it = s_fallbackMeshes.find(className);
+			const char *meshName = vessel->GetMeshName(m);
+			if (meshName && *meshName) {
+				auto it = s_fallbackMeshes.find(meshName);
 				if (it != s_fallbackMeshes.end()) {
 					hMesh = it->second;
 				} else {
-					hMesh = oapiLoadMeshGlobal(className);
-					s_fallbackMeshes[className] = hMesh;
-					if (hMesh) fprintf(stderr, "[OGLvVessel] Loaded fallback mesh '%s': %u groups\n",
-						className, oapiMeshGroupCount(hMesh));
+					hMesh = oapiLoadMeshGlobal(meshName);
+					s_fallbackMeshes[meshName] = hMesh;
 				}
 			}
 			if (!hMesh) continue;


### PR DESCRIPTION
## Summary

`OGLvVessel::Render` falls back to `oapiLoadMeshGlobal(...)` when the vessel's mesh template is null — the expected case when a vessel was assembled via the string-name overload `AddMesh(name, ofs)` rather than the preloaded-handle overload. The fallback was keyed on `vessel->GetClassName()`, which has no relationship to the mesh slot that's actually missing: for every Atlantis mission with a `CARGO_STATIC_MESH Carina_cradle` directive in the scenario, the fallback re-loaded the full 59-group orbiter mesh and drew a second shuttle floating at the cradle offset next to the real one.

Switch the fallback to `vessel->GetMeshName(idx)` — the same hint D3D9's `CopyMeshFromTemplate` consumes (`OVP/D3D9Client/VVessel.cpp:298`). Matched both the main and shadow passes so cargo / platform / any other string-name mesh casts the right silhouette.

Handle-loaded vessels (the common path) are unaffected — `hMesh` is non-null and the fallback never runs.

Discovered while testing Demo/Atlantis Ascent AP — the user reported a phantom orbiter hovering alongside the real stack. With the fix, the fallback resolves to `Carina_cradle.msh` as intended and the phantom disappears; the Atlantis launch itself is unchanged (AscentAP still fires via the #110 keystroke path).

## Test plan

- [x] Demo/Atlantis Ascent AP: no phantom shuttle, Carina cradle visible at the cargo-bay offset
- [x] Scenarios without `CARGO_STATIC_MESH`: Atlantis still renders normally (no regression — the fallback never runs)
- [ ] CI macOS green

🤖 Generated with [Claude Code](https://claude.com/claude-code)