### PR TITLE
macos: ship Blue Marble Earth base albedo via opt-in pipeline

### DIFF
--- a/OVP/OGLClient/OGLvPlanet.cpp
+++ b/OVP/OGLClient/OGLvPlanet.cpp
@@ -240,8 +240,13 @@ void OGLvPlanet::LoadTexture(const std::string &texturePath)
 	char name[64];
 	oapiGetObjectName(m_hObj, name, 64);
 
-	// Primary: <Name>.tex / .dds / .bmp
-	const char *extensions[] = { ".tex", ".dds", ".bmp", nullptr };
+	// Primary: <Name>.tex / .dds / .bmp / .png. The .png entry lets the macOS
+	// Blue Marble pipeline (`cmake/download_earth_lod8.py --earth-png …`) drop
+	// a 4096×2048 resampled Earth.png straight into Textures/ without needing
+	// a DDS compressor on the build host — the full LOD `.tree` archive is
+	// still the ideal long-term format (see #36) but the flat PNG already
+	// lifts Earth out of the two-colour EarthM.bmp fallback.
+	const char *extensions[] = { ".tex", ".dds", ".bmp", ".png", nullptr };
 	for (int i = 0; extensions[i]; i++) {
 		std::string tryPath = texturePath + name + extensions[i];
 		if (FileExists(tryPath.c_str())) {

--- a/cmake/download_earth_lod8.py
+++ b/cmake/download_earth_lod8.py
@@ -78,13 +78,55 @@ def fetch(spec, out_path: Path) -> None:
     print(f"[earth] wrote {out_path} ({len(data) / 1024 / 1024:.1f} MiB)")
 
 
+def resize_to_earth_png(src: Path, dst: Path, width: int, height: int) -> None:
+    """Load the full-resolution NASA mosaic and produce a much smaller
+    equirectangular `Earth.png` the OGL planet renderer can load as its base
+    albedo texture. Keeping the big upstream file cached alongside means
+    subsequent configures skip both download and resize when the target is
+    already up to date."""
+    try:
+        from PIL import Image
+    except ImportError:
+        raise SystemExit(
+            "[earth] Pillow (PIL) is required to resize the mosaic. "
+            "Install with `pip3 install --user pillow` and re-run configure.")
+
+    if dst.exists():
+        # Cheap existence check — the file size of a 4096×2048 RGB PNG sits in
+        # a predictable band. We compare against a rough floor so a truncated
+        # previous run re-generates; SHA pinning would require shipping a
+        # pre-computed hash that depends on Pillow's PNG encoder, which is
+        # worse for reproducibility than just regenerating when suspicious.
+        if dst.stat().st_size > 1_000_000:
+            print(f"[earth] {dst.name} already present, skip resize")
+            return
+
+    print(f"[earth] resizing {src.name} → {width}×{height} {dst.name}")
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with Image.open(src) as im:
+        im = im.convert("RGB")
+        im = im.resize((width, height), Image.LANCZOS)
+        im.save(dst, format="PNG", optimize=True)
+    print(f"[earth] wrote {dst} ({dst.stat().st_size / 1024 / 1024:.1f} MiB)")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=(
-        "Download the NASA Blue Marble Next Generation mosaic into the "
-        "Orbiter build tree. Tile-pyramid generation is a separate "
-        "offline step (see header comment)."))
+        "Download the NASA Blue Marble Next Generation mosaic and optionally "
+        "resample it into an equirectangular Earth.png that the OGL planet "
+        "renderer loads as its base albedo. Full LOD tile-pyramid generation "
+        "(Textures/Earth/Archive/Surf.tree) is still a separate offline step "
+        "— see the header comment."))
     ap.add_argument("--out", default=None,
-                    help="destination path; defaults to Textures/EarthBlueMarble.jpg")
+                    help="download destination; defaults to Textures/EarthBlueMarble.png")
+    ap.add_argument("--earth-png", default=None,
+                    help="if set, resize the downloaded mosaic to this path "
+                         "(e.g. Textures/Earth.png) so the OGL renderer picks "
+                         "it up without needing a full LOD pyramid")
+    ap.add_argument("--earth-png-width", type=int, default=4096,
+                    help="width in pixels for the resized Earth.png (default 4096)")
+    ap.add_argument("--earth-png-height", type=int, default=2048,
+                    help="height in pixels for the resized Earth.png (default 2048)")
     args = ap.parse_args()
 
     spec = BLUEMARBLE_SOURCES[0]
@@ -95,14 +137,20 @@ def main() -> int:
         print(f"[earth] download failed: {e}", file=sys.stderr)
         return 1
 
-    print()
-    print("[earth] Next steps (manual):")
-    print("[earth]   1. Tile-split the JPEG into Textures2/Earth/<lvl>/<x>_<y>.dds")
-    print("[earth]      using texconv (Windows) or compressonatorcli (POSIX).")
-    print("[earth]   2. Levels 1..8 cover the full globe at increasing resolution;")
-    print("[earth]      see Doc/HiResTextures.htm for the on-disk layout.")
-    print("[earth]   3. Drop the resulting tree into Textures2/Earth/ and the")
-    print("[earth]      OGL planet renderer will pick it up at scenario load.")
+    if args.earth_png:
+        try:
+            resize_to_earth_png(out, Path(args.earth_png),
+                                args.earth_png_width, args.earth_png_height)
+        except Exception as e:
+            print(f"[earth] resize failed: {e}", file=sys.stderr)
+            return 2
+    else:
+        print()
+        print("[earth] Next steps (manual):")
+        print("[earth]   1. Resample to a compact equirectangular via --earth-png")
+        print("[earth]      to get the OGL renderer's base albedo.")
+        print("[earth]   2. Tile-split the mosaic into Textures/Earth/Archive/Surf.tree")
+        print("[earth]      for full LOD zoom (separate offline pipeline).")
     return 0
 
 

--- a/cmake/macos_assets.cmake
+++ b/cmake/macos_assets.cmake
@@ -99,15 +99,21 @@ if(ORBITER_FETCH_EARTH_BLUEMARBLE)
 		message(WARNING "ORBITER_FETCH_EARTH_BLUEMARBLE=ON but no python3 "
 			"interpreter found — skipping Earth mosaic download.")
 	else()
-		set(_eb_out "${CMAKE_BINARY_DIR}/Textures/EarthBlueMarble.png")
-		message(STATUS "Fetching NASA Blue Marble mosaic → ${_eb_out}")
+		# Cache the full 530 MiB upstream outside Textures/ so the smaller
+		# Earth.png we actually ship isn't shadowed by it.
+		set(_eb_raw "${CMAKE_BINARY_DIR}/.orbiter_cache/EarthBlueMarble.png")
+		set(_eb_out "${CMAKE_BINARY_DIR}/Textures/Earth.png")
+		message(STATUS "Fetching + resampling NASA Blue Marble → ${_eb_out}")
 		execute_process(
 			COMMAND ${Python3_EXECUTABLE}
 				${CMAKE_SOURCE_DIR}/cmake/download_earth_lod8.py
-				--out ${_eb_out}
+				--out ${_eb_raw}
+				--earth-png ${_eb_out}
+				--earth-png-width 4096
+				--earth-png-height 2048
 			RESULT_VARIABLE _eb_rc)
 		if(NOT _eb_rc EQUAL 0)
-			message(WARNING "Blue Marble download failed (rc=${_eb_rc}); "
+			message(WARNING "Blue Marble pipeline failed (rc=${_eb_rc}); "
 				"see configure log for details. The build continues — "
 				"Earth will fall back to the bundled EarthM.bmp.")
 		endif()


### PR DESCRIPTION
## Summary

Partial fix for [#36](https://github.com/kanik0/orbiter/issues/36). [#51](https://github.com/kanik0/orbiter/pull/51) correctly documented that the macOS port's black-and-green Earth is the literal content of the two-colour `EarthM.bmp` fallback — not a rendering regression — but the visual gap it left open is what #36 actually tracks. This PR closes most of that gap without introducing a Windows-style asset-pack dependency.

The change has three small pieces:

1. **`cmake/download_earth_lod8.py`** gains a `--earth-png` / `--earth-png-{width,height}` pipeline that Pillow-resamples the already-downloaded NASA Blue Marble mosaic into a compact equirectangular PNG (default 4096×2048, ~5–8 MiB). Pillow is the only new runtime dep and is the standard Python imaging library on macOS; the script aborts with a clear message when it's missing.
2. **`cmake/macos_assets.cmake`** drives the pipeline when `-DORBITER_FETCH_EARTH_BLUEMARBLE=ON` is set, caches the 530 MiB upstream under `.orbiter_cache/` so subsequent configures don't re-download, and writes the resized output to `Textures/Earth.png`.
3. **`OGLvPlanet::LoadTexture`** learns to look for `.png` alongside the existing `.tex / .dds / .bmp` search list. No new shader code — the renderer just picks up the new Earth.png as the planet's base albedo.

## Scope

Opt-in by design. CI builds are untouched (flag defaults to `OFF`); the 530 MiB download is a deliberate one-time cost for developers who want the pretty Earth. The full LOD pyramid (`Textures/Earth/Archive/Surf.tree`) is still a separate offline step for crisp close-range views and continues to be tracked on [#36](https://github.com/kanik0/orbiter/issues/36).

## Test plan

- [x] Hand-authored placeholder PNG (blue ocean + rough green landmass) dropped into `Textures/Earth.png` on the current build: `OGLvPlanet` loaded it as Earth's albedo and rendered it in Demo/Today without any further configuration, confirming the loader path is live.
- [ ] Full opt-in run: `cmake --preset macos-arm64-debug -DORBITER_FETCH_EARTH_BLUEMARBLE=ON`, wait for the 530 MiB download + resize, launch Demo/Today — Earth should render natural blue + brown + green.
- [ ] CI macOS green with the flag left `OFF` (default path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)