### PR TITLE
fix(macos): drop broken /bin/sh conditional in DMG bundle step

### DIFF
--- a/cmake/codesign.cmake
+++ b/cmake/codesign.cmake
@@ -72,13 +72,17 @@ add_custom_target(macos-bundle-distributable
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		"${CMAKE_BINARY_DIR}/XRSound"       "${_dist}/Contents/Resources/XRSound"
 	# Doc / Html / Localdoc: copy source trees first, then overlay any
-	# PDFs produced during the build (e.g. XRSound User Manual) — the
-	# second copy_directory overwrites conflicting files, so generated
-	# PDFs win over their LaTeX/ODT sources.
+	# PDFs produced during the build (e.g. XRSound User Manual, which
+	# lands in ${CMAKE_BINARY_DIR}/Doc/). make_directory guarantees the
+	# overlay source exists even when no build step has populated it,
+	# and copy_directory onto an existing destination merges/overwrites
+	# so generated PDFs win over their LaTeX/ODT sources.
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		"${CMAKE_SOURCE_DIR}/Doc"           "${_dist}/Contents/Resources/Doc"
-	COMMAND /bin/sh -c "[ -d '${CMAKE_BINARY_DIR}/Doc' ] && \
-		cmake -E copy_directory '${CMAKE_BINARY_DIR}/Doc' '${_dist}/Contents/Resources/Doc' || true"
+	COMMAND ${CMAKE_COMMAND} -E make_directory
+		"${CMAKE_BINARY_DIR}/Doc"
+	COMMAND ${CMAKE_COMMAND} -E copy_directory
+		"${CMAKE_BINARY_DIR}/Doc"           "${_dist}/Contents/Resources/Doc"
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		"${CMAKE_SOURCE_DIR}/Html"          "${_dist}/Contents/Resources/Html"
 	COMMAND ${CMAKE_COMMAND} -E copy_directory


### PR DESCRIPTION
## Problem

The `on-push-macos` run on `main` ([24792367999](https://github.com/kanik0/orbiter/actions/runs/24792367999)) failed during `macos-bundle-distributable` with:

```
/bin/sh:  : command not found
/bin/sh:  true: command not found
ninja: build stopped: subcommand failed.
```

Cause: the `COMMAND /bin/sh -c "[ -d '.../Doc' ] && cmake -E copy_directory ... || true"` step I added in #121 gets quoted by CMake + ninja such that the shell receives the script body as multiple individual argv entries, so `sh` interprets an empty string as a command.

## Fix

Replace the conditional shell one-liner with a plain `cmake -E make_directory` of the overlay source, followed by an unconditional `cmake -E copy_directory`. `copy_directory` merges onto an existing destination, so the original goal — overlaying any PDFs produced during the build (e.g. the XRSound User Manual that `Sound/XRSound/CMakeLists.txt` drops into `\${CMAKE_BINARY_DIR}/Doc/`) on top of the `Doc/` source tree — still works without needing the shell-level existence check.

## Test plan

- [ ] `on-push-macos` workflow goes green on this branch.
- [ ] The produced `.app` still contains `Contents/Resources/Doc/XRSound/XRSound User Manual.pdf` (overlay from build tree) and `Contents/Resources/Doc/Scenery/AntelopeValley/*.pdf` (from source tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)