### PR TITLE
fix(macos): ship liblua.dylib and Modules/Celbody in .dmg (#124)

### DIFF
--- a/cmake/codesign.cmake
+++ b/cmake/codesign.cmake
@@ -39,9 +39,24 @@ set(_entitlements "${CMAKE_SOURCE_DIR}/cmake/Orbiter.entitlements.plist")
 # Distributable bundle: same layout as macos-bundle but data dirs are
 # *copied* (not symlinked) so the .app is self-contained and survives
 # the round-trip through hdiutil.
+# Build up the DEPENDS list with guards so the target stays valid even
+# when Lua / XRSound / the celbody subtree are disabled in a given
+# configuration. Orbiter is always required; the others pull in the
+# artifacts referenced by the COMMAND list below.
+set(_bundle_deps Orbiter)
+if(TARGET celbody_symlinks)
+	list(APPEND _bundle_deps celbody_symlinks)
+endif()
+if(TARGET XRSound_assets)
+	list(APPEND _bundle_deps XRSound_assets)
+endif()
+if(TARGET lua)
+	list(APPEND _bundle_deps lua)
+endif()
+
 add_custom_target(macos-bundle-distributable
 	COMMENT "Creating distributable Orbiter.app (copy data dirs)..."
-	DEPENDS Orbiter
+	DEPENDS ${_bundle_deps}
 	COMMAND ${CMAKE_COMMAND} -E rm -rf "${_dist}"
 	COMMAND ${CMAKE_COMMAND} -E make_directory "${_dist}/Contents/MacOS"
 	COMMAND ${CMAKE_COMMAND} -E make_directory "${_dist}/Contents/Resources"
@@ -59,6 +74,12 @@ add_custom_target(macos-bundle-distributable
 		"${CMAKE_BINARY_DIR}/Scenarios"     "${_dist}/Contents/Resources/Scenarios"
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		"${CMAKE_BINARY_DIR}/Modules"       "${_dist}/Contents/Resources/Modules"
+	# liblua.dylib is produced in the build root by Extern/Lua and is
+	# referenced via @rpath by every vessel module and Lua plugin.
+	# Drop it inside Modules/ so the dylibs resolve it via @loader_path
+	# (Modules/*.dylib) or @loader_path/.. (Modules/Plugin/*.dylib).
+	COMMAND ${CMAKE_COMMAND} -E copy
+		"${CMAKE_BINARY_DIR}/liblua.dylib"  "${_dist}/Contents/Resources/Modules/"
 	COMMAND ${CMAKE_COMMAND} -E copy_directory
 		"${CMAKE_BINARY_DIR}/Fonts"         "${_dist}/Contents/Resources/Fonts"
 	COMMAND ${CMAKE_COMMAND} -E copy_directory


### PR DESCRIPTION
Fixes #124.

## Summary

Two packaging bugs made the installed `.dmg` boot to a black 3D scene:

1. **`liblua.dylib` missing from bundle.** Every vessel module and Lua plugin in the bundle references `@rpath/liblua.dylib`, but the library is produced by `Extern/Lua` in `\${CMAKE_BINARY_DIR}/liblua.dylib` — not under `Modules/` — so the copy step never picked it up. None of the three rpaths (`@loader_path`, `@executable_path`, `@loader_path/..`) pointed at a directory that contained it, so `dlopen(libDeltaGlider.dylib)` etc. silently failed with `(code 0)`. No focus vessel → degenerate camera → black scene.

2. **`Modules/Celbody/` missing from bundle.** `celbody_symlinks` (which bridges atmosphere modules into `Modules/Celbody/<Planet>/Atmosphere/`) was `ALL`-tagged but not in the `DEPENDS` chain of `macos-bundle-distributable`. The CI workflow uses `cmake --build --target macos-dmg`, which only pulls in targets reachable from `macos-dmg` → `macos-codesign` → `macos-bundle-distributable` → `Orbiter`. `ALL` doesn't fire under `--target X`. Result: `copy_directory Modules/` ran before the Celbody subtree existed, so every atmosphere (VenusAtm2006, EarthAtmJ71G, MarsAtm2006) was absent.

## Fix

- Copy `\${CMAKE_BINARY_DIR}/liblua.dylib` into `Contents/Resources/Modules/liblua.dylib` — resolvable from both `Modules/*.dylib` (`@loader_path`) and `Modules/Plugin/*.dylib` (`@loader_path/..`).
- Add `celbody_symlinks`, `XRSound_assets` and `lua` to `DEPENDS` of `macos-bundle-distributable`, each guarded with `if(TARGET ...)`.

## Test plan

- [ ] `on-push-macos` goes green.
- [ ] Install the resulting `.dmg`, run: `xattr -dr com.apple.quarantine /Applications/Orbiter.app && open /Applications/Orbiter.app`. Pick Demo / Today (or DG in LEO). Expected: 3D scene renders (stars, planet, vessel mesh).
- [ ] `~/Library/Logs/Orbiter/Orbiter.log` should no longer report `Failed loading module Modules/Plugin/libLuaMFD.dylib`, `Could not load vessel module: DeltaGlider`, or the three `VenusAtm2006 / EarthAtmJ71G / MarsAtm2006` not-found errors.
- [ ] `ls /Applications/Orbiter.app/Contents/Resources/Modules/liblua.dylib` exists.
- [ ] `ls /Applications/Orbiter.app/Contents/Resources/Modules/Celbody/Venus/Atmosphere/` contains `libVenusAtm2006.dylib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)