### PR TITLE
fix(macos): populate MFD side-button labels on panel re-creation (#123)

### DIFF
--- a/Src/Orbiter/Defpanel.cpp
+++ b/Src/Orbiter/Defpanel.cpp
@@ -96,6 +96,17 @@ DefaultPanel::DefaultPanel (Pane *_pane, int cidx): pane(_pane)
 	mfdPen = NULL;
 
 	InitDeviceObjects ();
+
+	// Populate MFD side-button labels for any Instrument that already
+	// exists on this Pane. SetGeometry() has left their UVs on a blank
+	// placeholder slot, and RepaintMFDButtons() is otherwise only invoked
+	// from Pane::OpenMFD() → MFDModeChanged(), which is skipped when the
+	// panel is re-instantiated (e.g. F1 back to generic cockpit) with the
+	// same MFD mode still active. The bottom PWR / SEL / MNU buttons use
+	// texture-baked glyphs laid out in SetGeometry() and aren't affected.
+	// RepaintMFDButtons() short-circuits when gc or mfd[id].instr is null,
+	// so this is a no-op on first boot before any MFD has been opened.
+	for (int i = 0; i < 2; i++) RepaintMFDButtons(i);
 }
 
 DefaultPanel::~DefaultPanel ()


### PR DESCRIPTION
Fixes #123.

## Summary

In the generic 2D cockpit panel the 6 side buttons flanking each MFD were rendering empty, while the 3 bottom buttons (PWR / SEL / MNU) showed their labels correctly.

## Root cause

Two different code paths behind the button labels:

- **Bottom buttons** use UVs that `DefaultPanel::SetGeometry()` bakes directly into the panel texture ([Defpanel.cpp:201](Src/Orbiter/Defpanel.cpp#L201) — `(197.0f+i*29.0f)/texw` points at the pre-rendered PWR/SEL/MNU glyphs). They are correct as soon as the mesh is built.
- **Side buttons** use a placeholder UV (`350.0f/texw`, a blank region of the texture) that [`RepaintMFDButtons()`](Src/Orbiter/Defpanel.cpp#L719) patches by calling `Instrument::ButtonLabel(bt)` and rewriting the 12 character-slot vertices per button to the correct glyphs in the font atlas.

`RepaintMFDButtons()` is invoked only through `DefaultPanel::MFDModeChanged()`, which is only fired by [`Pane::OpenMFD()`](Src/Orbiter/Pane.cpp#L909). When the user flips panel mode (e.g. F1 back to generic cockpit) while an MFD is already open at the right mode, `Pane::OpenMFD()` short-circuits at line 857 (*"nothing to do"*) and never fires `MFDModeChanged()`, so the freshly-built `DefaultPanel` keeps its placeholder UVs until the user changes MFD mode. Bottom buttons aren't affected because they don't rely on `RepaintMFDButtons()`.

This same code path runs on Windows too — I suspect the Windows reference build happens to open its MFDs through a flow that always triggers `MFDModeChanged()` (e.g. on first F1). The fix is independent of the platform.

## Fix

Call `RepaintMFDButtons(0)` and `RepaintMFDButtons(1)` at the end of the `DefaultPanel` constructor, after `InitDeviceObjects()`. The function already short-circuits on `!gc || !pane->mfd[id].instr`, so it is a no-op on first boot when no MFD has been opened yet.

## Test plan

- [ ] Launch Demo / Today, F1 to generic cockpit. Both MFDs show their 6 side buttons labelled (`PRJ`, `FRM`, `REF`, `DST`, `MOD`, `BCK` etc. for Orbit MFD).
- [ ] Open SEL, pick a different MFD mode. Side labels update to the new mode's buttons.
- [ ] F1 to external view, F1 back to cockpit — labels remain populated (regression check for the original bug).
- [ ] Shift+F1 MFD mode selector works on both MFDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)