### PR TITLE
fix(macos): unblock Dragonfly scenarios — SIGSEGV on panel init (#130)

### DIFF
--- a/OVP/OGLClient/OGLClient.cpp
+++ b/OVP/OGLClient/OGLClient.cpp
@@ -522,6 +522,18 @@ void OGLClient::BlitQuad(OGLSurface *tgt, DWORD tgtx, DWORD tgty, DWORD tgtw, DW
 {
 	if (!m_blitShader || !m_blitVAO || !src) return;
 
+	// Bail on degenerate surfaces before touching GL state. A source or
+	// target whose GL texture failed to allocate (e.g. a Dragonfly panel
+	// area registered with a bogus size in #130) sits here as an
+	// OGLSurface with sane-looking metadata but no backing storage —
+	// sampling or attaching it otherwise trips a SIGSEGV inside the
+	// driver.
+	if (src->GetTexture() == 0 ||
+	    src->GetWidth() == 0 || src->GetHeight() == 0 ||
+	    src->GetWidth() > 16384 || src->GetHeight() > 16384) return;
+	if (tgt && (tgt->GetWidth() == 0 || tgt->GetHeight() == 0 ||
+	            tgt->GetWidth() > 16384 || tgt->GetHeight() > 16384)) return;
+
 	// Compute source UV coords
 	float sw = (float)src->GetWidth(), sh = (float)src->GetHeight();
 	float u0 = (float)srcx / sw, v0 = (float)srcy / sh;
@@ -603,7 +615,13 @@ void OGLClient::BlitQuad(OGLSurface *tgt, DWORD tgtx, DWORD tgty, DWORD tgtw, DW
 	// colorkey path.
 	glDisable(GL_BLEND);
 	glDisable(GL_DEPTH_TEST);
-	glViewport(0, 0, tgt->GetWidth(), tgt->GetHeight());
+	// Viewport is already configured above: tgt->BindFBO() sets it to the
+	// target surface's dimensions, and the backbuffer branch sets it to
+	// (m_viewW, m_viewH). The earlier unconditional
+	// `glViewport(0, 0, tgt->GetWidth(), tgt->GetHeight())` here
+	// dereferenced tgt and SIGSEGV'd whenever a caller legitimately passed
+	// tgt=NULL (Panel::SetArea with a NULL Panel::surf after a failed
+	// DefineBackground, #130).
 
 	glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 

--- a/OVP/OGLClient/OGLSurface.cpp
+++ b/OVP/OGLClient/OGLSurface.cpp
@@ -73,6 +73,24 @@ bool OGLSurface::Create(DWORD w, DWORD h, DWORD attrib)
 
 bool OGLSurface::CreateEx(DWORD w, DWORD h, DWORD attrib, int samples, bool wantStencil)
 {
+	// Reject obviously-bogus dimensions before any GL call. Passing
+	// w=2625193536 to glTexImage2D silently fails on the macOS driver —
+	// the texture handle is valid but the storage is undefined, which
+	// later trips FRAMEBUFFER_INCOMPLETE_ATTACHMENT on FBO attachment
+	// and a SIGSEGV inside BlitQuad when the caller samples the phantom
+	// texture. Upper bound is the most conservative GL_MAX_TEXTURE_SIZE
+	// any supported macOS/Metal GPU exposes (Apple Silicon reports
+	// 16384, Intel HD 4000 8192). Anything larger here is a caller bug.
+	// #130 tracks the Dragonfly panel-area registration that currently
+	// asks for 2625193536x12.
+	if (w == 0 || h == 0 || w > 16384 || h > 16384) {
+		fprintf(stderr,
+		        "[OGLSurface] CreateEx rejected bogus size %ux%u "
+		        "(attrib=0x%04lx)\n",
+		        (unsigned)w, (unsigned)h, (unsigned long)attrib);
+		return false;
+	}
+
 	m_width        = w;
 	m_height       = h;
 	m_attrib       = attrib;

--- a/Src/Orbiter/GraphicsAPI.cpp
+++ b/Src/Orbiter/GraphicsAPI.cpp
@@ -587,8 +587,19 @@ void GraphicsClient::clbkRender2DPanel (SURFHANDLE *hSurf, MESHHANDLE hMesh, MAT
 
 SURFHANDLE GraphicsClient::clbkCreateSurface (HBITMAP hBmp)
 {
-	BITMAP bm;
+	// On macOS/Linux HBITMAP and the GDI bitmap helpers are empty stubs
+	// (OrbiterPlatform.h): CreateCompatibleBitmap returns nullptr, and
+	// GetObject(HBITMAP, …) is a no-op that doesn't touch the caller's
+	// BITMAP struct. Without zero-initialisation `bm` then held stack
+	// garbage and we propagated a ~2.3-billion-pixel width down to
+	// clbkCreateSurface → OGL driver SIGSEGV when the subsequent blit
+	// sampled the phantom texture (#130, Dragonfly panel background).
+	// Refuse a NULL bitmap handle up front and zero the BITMAP shadow so
+	// a failing GetObject surfaces as a NULL SURFHANDLE instead.
+	if (!hBmp) return nullptr;
+	BITMAP bm = {};
 	GetObject (hBmp, sizeof(bm), &bm);
+	if (bm.bmWidth <= 0 || bm.bmHeight <= 0) return nullptr;
 	SURFHANDLE surf = clbkCreateSurface (bm.bmWidth, bm.bmHeight);
 	if (surf) {
 		if (!clbkCopyBitmap (surf, hBmp, 0, 0, 0, 0)) {

--- a/Src/Orbiter/Panel.cpp
+++ b/Src/Orbiter/Panel.cpp
@@ -141,15 +141,22 @@ void Panel::DefineBackground (HBITMAP hBmp, DWORD flag, DWORD _ck)
 {
 	if (!gc) return;
 
-	//HRESULT res;
-	BITMAP bm;
-
 	if (surf) gc->clbkReleaseSurface (surf);
+
+	// Zero-init so macOS/Linux — where GetObject is a no-op stub
+	// (OrbiterPlatform.h) and hBmp is often nullptr because the GDI
+	// helpers that produced it are also stubs — don't leak uninit
+	// stack bytes into srcW/srcH. Without this the Dragonfly panel
+	// background produced a ~2.3-billion-pixel srcW and later crashed
+	// the OGL client in BlitQuad (#130).
+	BITMAP bm = {};
+	if (!hBmp) { surf = nullptr; srcW = srcH = 0; return; }
 
 	// bitmap size
     GetObject (hBmp, sizeof(bm), &bm);
     srcW = bm.bmWidth;
 	srcH = bm.bmHeight;
+	if (srcW <= 0 || srcH <= 0) { surf = nullptr; srcW = srcH = 0; return; }
 	tgtW = (int)(scale*srcW);
 	tgtH = (int)(scale*srcH);
 
@@ -219,6 +226,22 @@ void Panel::DefineArea (int aid, const RECT &pos, int draw_mode, int mouse_mode,
 {
 	// sanity-checks
 	if (draw_mode == PANEL_REDRAW_NEVER) bkmode = PANEL_MAP_NONE;
+
+	// Caller-passed RECT sanity. A malformed RECT (right < left, bottom
+	// < top, or an area wider/taller than the largest MFD the engine
+	// ships with) will propagate into clbkCreateSurface as a garbage
+	// width/height and crash the OGL client downstream (#130). Drop the
+	// registration and log the offender so the upstream bug can be
+	// pinned to a specific area id + rect.
+	const int w = pos.right - pos.left;
+	const int h = pos.bottom - pos.top;
+	if (w <= 0 || h <= 0 || w > 16384 || h > 16384) {
+		LOGOUT_ERR("Panel::DefineArea skipping aid=%d with malformed RECT "
+		           "(left=%ld, top=%ld, right=%ld, bottom=%ld) → %dx%d",
+		           aid, (long)pos.left, (long)pos.top,
+		           (long)pos.right, (long)pos.bottom, w, h);
+		return;
+	}
 
 	if (narea == nareabuf) {
 		Area **tmp = new Area*[nareabuf += 32]; TRACENEW

--- a/Src/Vessel/Dragonfly/CMakeLists.txt
+++ b/Src/Vessel/Dragonfly/CMakeLists.txt
@@ -47,7 +47,7 @@ add_custom_command(
 
 add_custom_command(
 	TARGET Dragonfly PRE_BUILD
-	COMMAND ${CMAKE_COMMAND} -E copy_directory ${MESH_SOURCE_DIR}/ ${CMAKE_BINARY_DIR}/Meshes
+	COMMAND ${CMAKE_COMMAND} -E copy_directory ${MESH_SOURCE_DIR}/ ${CMAKE_BINARY_DIR}/Meshes/Dragonfly
 )
 
 add_custom_command(


### PR DESCRIPTION
## Summary

Closes #130.

Dragonfly scenarios crashed at `Panel::SetArea → OGLClient::clbkBlt → OGLClient::BlitQuad` the moment the panel initialised. The chain had three independent problems.

## Root cause chain

### 1. Uninitialised BITMAP on macOS

`OrbiterPlatform.h` stubs the GDI bitmap helpers: `CreateCompatibleBitmap` returns `nullptr`, and `GetObject(HBITMAP, int, void*)` is a no-op that returns FALSE without touching the caller's BITMAP.

Dragonfly's `Panel::MakeYourBackground` calls `CreateCompatibleBitmap` and hands the resulting NULL `HBITMAP` to `oapiRegisterPanelBackground`. Downstream:
- [`GraphicsClient::clbkCreateSurface(HBITMAP)`](Src/Orbiter/GraphicsAPI.cpp) had `BITMAP bm;` + no-op `GetObject` → `bm.bmWidth/bmHeight` hold stack garbage. `clbkCreateSurface(2327757600, 11, ...)` then tried to allocate a 2.3-billion-pixel texture; the driver silently failed but kept an OGLSurface handle with a valid id and bogus dimensions.
- [`Panel::DefineBackground`](Src/Orbiter/Panel.cpp) had the same pattern for the panel-surface path.

**Fix**: zero-init `bm`, reject `hBmp==nullptr`, reject `bmWidth<=0 || bmHeight<=0` at both sites.

### 2. NULL-tgt deref in OGLClient::BlitQuad

[`BlitQuad`](OVP/OGLClient/OGLClient.cpp) accepts `tgt==NULL` (blit to backbuffer) and configures viewport correctly at the top. A redundant unconditional `glViewport(0, 0, tgt->GetWidth(), tgt->GetHeight())` right before `glDrawArrays` dereferenced `tgt` anyway. `Panel::SetArea` with a NULL `Panel::surf` hit this and SIGSEGV'd.

**Fix**: removed the redundant call — viewport is already correctly configured by `tgt->BindFBO()` on the RTT branch and by `glViewport(0, 0, m_viewW, m_viewH)` on the backbuffer branch.

### 3. Defence-in-depth

Added guards so downstream code never receives out-of-range dimensions even if a future caller slips through:
- [`OGLSurface::CreateEx`](OVP/OGLClient/OGLSurface.cpp): reject `w==0 || h==0 || w>16384 || h>16384` before any GL call, log the attempted size + attrib.
- [`OGLClient::BlitQuad`](OVP/OGLClient/OGLClient.cpp): reject src/tgt with `GetTexture()==0` or out-of-range dimensions before touching GL state.
- [`Panel::DefineArea`](Src/Orbiter/Panel.cpp): validate the caller's RECT and emit a single `LOGOUT_ERR` naming the `aid` on malformed input.

### 4. Dragonfly mesh deployment

[`Src/Vessel/Dragonfly/CMakeLists.txt`](Src/Vessel/Dragonfly/CMakeLists.txt) copied meshes to `${CMAKE_BINARY_DIR}/Meshes/` directly, but the vessel code asks `oapiLoadMeshGlobal(\"Dragonfly//Dragonfly\")` → expects `Meshes/Dragonfly/Dragonfly.msh`. Every other vessel CMakeLists copies to a vessel-named subfolder; Dragonfly was the outlier. Fixed.

## Known residual

Dragonfly's 2D panel background still ships empty because its GDI construction (`CreateCompatibleBitmap` / `SelectObject` / `BitBlt`) has no macOS equivalent in the current platform-stub layer. The scenario now loads and flies; fleshing out the GDI stubs is follow-up work outside #130's scope — tracked implicitly by #129 (Dragonfly side-button / panel audit is now unblocked).

## Test plan

- [x] Dragonfly scenario loads without SIGSEGV (user-confirmed).
- [ ] No regressions on DG / ShuttleA / Atlantis / ShuttlePB / HST (all unrelated to the HBITMAP path).
- [ ] `Orbiter.log` shows no new `Panel::DefineArea skipping aid=…` or `[OGLSurface] CreateEx rejected bogus size …` entries on any shipping vessel — if it does, that's a bug the new guards will catch cleanly.

## Related

- Unblocks #129 (Dragonfly can now be added to the side-button label audit).
- Companion to [kanik0#131](https://github.com/kanik0/orbiter/pull/131) (#128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)