### PR TITLE
fix(macos): decompress S3TC textures on demand for FBO targets (#129)

### DIFF
--- a/OVP/OGLClient/OGLSurface.cpp
+++ b/OVP/OGLClient/OGLSurface.cpp
@@ -6,6 +6,24 @@
 #include "OGLSurface.h"
 #include <cstdio>
 #include <cstring>
+#include <vector>
+
+// S3TC compressed-texture internal-format constants. Apple's OpenGL/gl3.h
+// doesn't declare these by default, but the driver does accept them via
+// GL_EXT_texture_compression_s3tc (enabled by default on macOS Core
+// Profile). OGLTexture.cpp has the same fallbacks.
+#ifndef GL_COMPRESSED_RGB_S3TC_DXT1_EXT
+#define GL_COMPRESSED_RGB_S3TC_DXT1_EXT   0x83F0
+#endif
+#ifndef GL_COMPRESSED_RGBA_S3TC_DXT1_EXT
+#define GL_COMPRESSED_RGBA_S3TC_DXT1_EXT  0x83F1
+#endif
+#ifndef GL_COMPRESSED_RGBA_S3TC_DXT3_EXT
+#define GL_COMPRESSED_RGBA_S3TC_DXT3_EXT  0x83F2
+#endif
+#ifndef GL_COMPRESSED_RGBA_S3TC_DXT5_EXT
+#define GL_COMPRESSED_RGBA_S3TC_DXT5_EXT  0x83F3
+#endif
 
 namespace ogl {
 
@@ -154,11 +172,54 @@ int OGLSurface::Release()
 	return rc;
 }
 
+// ---------------------------------------------------------------------------
+// DXTn/BCn textures cannot be attached to an FBO — glFramebufferTexture2D on a
+// compressed internal format returns GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT.
+// Most vessel panel textures ship as DXT5 (dg_panel.dds is 2048x1024 DXT5)
+// AND are later self-blitted by the vessel plugin to paint glyphs / gauges
+// onto the panel itself. Without this upgrade the self-blit silently no-ops
+// and the DG 2D MFD side-button labels stay blank (#129).
+//
+// glGetTexImage on a compressed texture decompresses client-side via the
+// driver, so we can reupload as GL_RGBA8 in one round-trip. One-off per RT-
+// using texture — the memory hit is 4× for the affected sub-set (DG panel:
+// 2 MB → 8 MB).
+static void DecompressToRGBA8IfCompressed(GLuint texId, DWORD width, DWORD height, bool regenMips)
+{
+	if (!texId) return;
+	glBindTexture(GL_TEXTURE_2D, texId);
+	GLint fmt = 0;
+	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &fmt);
+	const bool compressed =
+		fmt == GL_COMPRESSED_RGB_S3TC_DXT1_EXT  ||
+		fmt == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT ||
+		fmt == GL_COMPRESSED_RGBA_S3TC_DXT3_EXT ||
+		fmt == GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
+	if (!compressed) { glBindTexture(GL_TEXTURE_2D, 0); return; }
+
+	std::vector<unsigned char> pixels((size_t)width * height * 4);
+	glPixelStorei(GL_PACK_ALIGNMENT, 1);
+	glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width, height, 0,
+	             GL_RGBA, GL_UNSIGNED_BYTE, pixels.data());
+	if (regenMips) glGenerateMipmap(GL_TEXTURE_2D);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	fprintf(stderr,
+	        "[OGLSurface] Decompressed DXT%c → RGBA8 for RT use "
+	        "(tex=%u, %ux%u)\n",
+	        (fmt == GL_COMPRESSED_RGB_S3TC_DXT1_EXT ||
+	         fmt == GL_COMPRESSED_RGBA_S3TC_DXT1_EXT) ? '1' :
+	        fmt == GL_COMPRESSED_RGBA_S3TC_DXT3_EXT ? '3' : '5',
+	        texId, (unsigned)width, (unsigned)height);
+}
+
 GLuint OGLSurface::EnsureFBO()
 {
 	if (m_fbo) return m_fbo;
 	if (!m_texId) return 0;
 	if (m_fboFailed) return 0;
+
+	DecompressToRGBA8IfCompressed(m_texId, m_width, m_height, HasMipmaps());
 
 	// --- Single-sample resolve FBO (always built). ---------------------------
 	glGenFramebuffers(1, &m_fbo);


### PR DESCRIPTION
## Summary

Closes #129.

Audits MFD side-button labels across every shipping vessel + view on macOS ARM64, finds the one remaining broken path (DG 2D panel), and fixes it by decompressing S3TC textures on demand when they're used as FBO colour attachments.

## The bug

DG's [`MfdButtonCol::Redraw2D`](Src/Vessel/DeltaGlider/MfdSubsys.cpp) paints button labels by self-blitting pre-baked font glyphs from the panel texture onto the button-area region of the **same** texture:

```cpp
oapiBlt(surf, surf, xcnt-14, lbly[btn], 773, 22, 28, CHH);
```

The OGL client routes self-blits through [`BlitFramebufferSelf`](OVP/OGLClient/OGLClient.cpp), which calls [`OGLSurface::EnsureFBO`](OVP/OGLClient/OGLSurface.cpp) to attach the surface texture to a fresh FBO. DG's panel texture is `Textures/dg_panel.dds` — **DXT5 compressed** — and macOS Core Profile GL 4.1 (like every spec-conformant GL) refuses compressed textures as colour attachments with `GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT`. `EnsureFBO` returned 0, `BlitFramebufferSelf` returned false, `oapiBlt` was a no-op, labels stayed blank.

## The fix

Detect `GL_COMPRESSED_*_S3TC_DXT{1,3,5}_EXT` internal formats at the top of `EnsureFBO` and decompress them to `GL_RGBA8` in place before attachment. `glGetTexImage(…, GL_RGBA, GL_UNSIGNED_BYTE, …)` asks the driver to decompress to client memory, so a single download + `glTexImage2D` reupload is enough. One-off per texture that actually becomes an RTT — the subsequent short-circuit in `EnsureFBO (if m_fbo) return m_fbo` keeps the blit path free.

Memory hit: 4× for the affected subset. DG panel is 2 MB DXT5 → 8 MB RGBA8.

## #129 audit matrix

Tested on macOS ARM64 (Apple M2, Metal-wrapped GL 4.1):

| Vessel     | 2D panel        | VC                | Generic cockpit |
|------------|-----------------|-------------------|-----------------|
| DeltaGlider| **FIXED**       | ok (via [kanik0#131](https://github.com/kanik0/orbiter/pull/131)) | ok |
| DG-S       | N/A             | N/A               | —               |
| ShuttleA   | ok              | ok                | —               |
| ShuttlePB  | N/A             | N/A               | —               |
| Atlantis   | N/A             | ok*               | —               |
| HST        | —               | ok                | —               |
| Dragonfly  | see [kanik0#133](https://github.com/kanik0/orbiter/issues/133) | ok (via [kanik0#132](https://github.com/kanik0/orbiter/pull/132)) | — |
| generic    | —               | —                 | ok              |

\* Atlantis AscentMFD rows are visually tight where the MFD draws consecutive rows exactly `ch` pixels apart — pre-existing behaviour, known residual documented in the #128 / [kanik0#131](https://github.com/kanik0/orbiter/pull/131) body.

Dragonfly 2D panel background is still empty because the vessel constructs it through GDI-only helpers that are stubs on macOS — tracked separately in [kanik0#133](https://github.com/kanik0/orbiter/issues/133) and out of scope for #129.

## Test plan

- [x] DG 2D panel MFD side-buttons show 3-char mode labels (user-confirmed).
- [x] DG 2D panel MODE SELECT list shows `>`/`<` arrows on every row.
- [x] All other vessels / views unchanged.
- [ ] `Orbiter.log` shows one `[OGLSurface] Decompressed DXT5 → RGBA8` entry the first time a compressed RTT texture is touched; subsequent frames are silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)