### PR TITLE
fix(macos): render Dragonfly 2D panel background (partial) + BGR/RGB colour swap (#133)

### DIFF
--- a/OVP/OGLClient/OGLSketchpad.cpp
+++ b/OVP/OGLClient/OGLSketchpad.cpp
@@ -364,13 +364,18 @@ DWORD OGLSketchpad::GetTextWidth(const char *str, int len) {
 
 void OGLSketchpad::PackColor(DWORD col, float out[4]) const
 {
-	// Orbiter stores 0xBBGGRR. The alpha byte (bits 24-31) is optional;
-	// the ColorCompatibility default treats alpha==0 as "fully opaque"
-	// which is what every D3D9 caller historically assumed. Sketchpads
-	// that opt out (ColorCompatibility(false)) get the raw alpha byte.
-	float r = ((col >> 16) & 0xFF) / 255.0f;
+	// Orbiter stores 0xBBGGRR — B in the high byte, G in the middle, R
+	// in the low byte, matching the layout Windows' RGB(r,g,b) macro
+	// produces. The previous extraction here swapped R and B (it
+	// assigned the BB byte to the local "r" variable), so anything
+	// non-symmetric — col_red1, col_yellow1, or RGB(145,48,48) — came
+	// out with R and B transposed. Green/grey/white stayed fine, which
+	// is why the bug stayed hidden until #133 exercised a dark-red fill.
+	// The alpha byte (bits 24-31) is optional; ColorCompatibility's
+	// default treats alpha==0 as "fully opaque", matching D3D9 legacy.
+	float r = ( col        & 0xFF) / 255.0f;
 	float g = ((col >>  8) & 0xFF) / 255.0f;
-	float b = ( col        & 0xFF) / 255.0f;
+	float b = ((col >> 16) & 0xFF) / 255.0f;
 	float a = ((col >> 24) & 0xFF) / 255.0f;
 	if (m_colourCompat && a < 1.0f / 255.0f) a = 1.0f;
 	out[0] = r; out[1] = g; out[2] = b; out[3] = a;

--- a/Orbitersdk/include/OrbiterAPI.h
+++ b/Orbitersdk/include/OrbiterAPI.h
@@ -5270,6 +5270,18 @@ OAPIFUNC bool oapiUnregisterExternMFD (ExternMFD *emfd);
 OAPIFUNC void oapiRegisterPanelBackground (HBITMAP hBmp, DWORD flag = PANEL_ATTACH_BOTTOM|PANEL_MOVEOUT_BOTTOM,
 				                           DWORD ck = (DWORD)-1);
 
+/**
+ * \brief SURFHANDLE-based alternative to \ref oapiRegisterPanelBackground.
+ * Needed by vessel plugins that can't produce an HBITMAP — macOS/Linux
+ * builds where CreateCompatibleBitmap is an empty stub. Ownership of
+ * `hSurf` transfers to the engine; do not release it yourself. Named
+ * distinctly from the HBITMAP overload because both parameter types
+ * are `void*` typedefs on macOS/Linux and overload resolution is
+ * ambiguous there.
+ */
+OAPIFUNC void oapiRegisterPanelBackgroundSurface (SURFHANDLE hSurf,
+                                                  DWORD flag = PANEL_ATTACH_BOTTOM|PANEL_MOVEOUT_BOTTOM);
+
 	/**
 	* \anchor register_p_a
 	* \brief Defines a rectangular area within a panel to receive mouse or redraw notifications.

--- a/Src/Orbiter/OrbiterAPI.cpp
+++ b/Src/Orbiter/OrbiterAPI.cpp
@@ -1783,6 +1783,11 @@ DLLEXPORT void oapiRegisterPanelBackground (HBITMAP hBmp, DWORD flag, DWORD ck)
 	g_pane->RegisterPanelBackground (hBmp, flag, ck);
 }
 
+DLLEXPORT void oapiRegisterPanelBackgroundSurface (SURFHANDLE hSurf, DWORD flag)
+{
+	g_pane->RegisterPanelBackground (hSurf, flag);
+}
+
 DLLEXPORT void oapiRegisterPanelArea (int id, const RECT &pos, int draw_event, int mouse_event, int bkmode)
 {
 	g_pane->RegisterPanelArea (id, pos, draw_event, mouse_event, bkmode);

--- a/Src/Orbiter/Pane.cpp
+++ b/Src/Orbiter/Pane.cpp
@@ -1194,7 +1194,10 @@ void Pane::RegisterPanelBackground (HBITMAP hBmp, DWORD flag, DWORD ck)
 
 void Pane::RegisterPanelBackground (SURFHANDLE hSurf, DWORD flag)
 {
-	// todo
+	if (panel) panel->DefineBackgroundSurface (hSurf, flag);
+	// Ownership transfers to Panel::DefineBackgroundSurface, which will
+	// release the surface when the panel is torn down. No Orbiter-side
+	// cleanup required here.
 }
 
 void Pane::RegisterPanelArea (int aid, const RECT &pos, int draw_mode, int mouse_mode, int bkmode)

--- a/Src/Orbiter/Panel.cpp
+++ b/Src/Orbiter/Panel.cpp
@@ -222,6 +222,76 @@ void Panel::DefineBackground (HBITMAP hBmp, DWORD flag, DWORD _ck)
 	visible = true;
 }
 
+void Panel::DefineBackgroundSurface (SURFHANDLE hSurf, DWORD flag)
+{
+	if (!gc) return;
+
+	if (surf) gc->clbkReleaseSurface (surf);
+
+	// Direct SURFHANDLE entry for vessels whose GDI-based bitmap path is
+	// not usable (macOS/Linux stubs of CreateCompatibleBitmap). Ownership
+	// of hSurf transfers here — the panel will release it at teardown.
+	if (!hSurf) { surf = nullptr; srcW = srcH = 0; return; }
+
+	DWORD w = 0, h = 0;
+	if (!gc->clbkGetSurfaceSize (hSurf, &w, &h) || w <= 0 || h <= 0) {
+		gc->clbkReleaseSurface (hSurf);
+		surf = nullptr; srcW = srcH = 0;
+		return;
+	}
+
+	surf = hSurf;
+	srcW = (int)w;
+	srcH = (int)h;
+	tgtW = (int)(scale*srcW);
+	tgtH = (int)(scale*srcH);
+
+	shiftflag = flag & 0x00FF;
+	if (shiftflag & PANEL_ATTACH_BOTTOM) shiftflag |= PANEL_MOVEOUT_TOP;
+	if (shiftflag & PANEL_ATTACH_TOP)    shiftflag |= PANEL_MOVEOUT_BOTTOM;
+	if (shiftflag & PANEL_ATTACH_LEFT)   shiftflag |= PANEL_MOVEOUT_RIGHT;
+	if (shiftflag & PANEL_ATTACH_RIGHT)  shiftflag |= PANEL_MOVEOUT_LEFT;
+
+	if (shiftflag & PANEL_ATTACH_TOP && shiftflag & PANEL_ATTACH_BOTTOM) {
+		if (tgtH < pane->H) {
+			scale = (double)pane->H/(double)srcH;
+			tgtW = (int)(scale*srcW);
+			tgtH = (int)(scale*srcH);
+			iscale  = 1.0/scale;
+			scaled  = (scale != 1.0);
+		}
+	}
+
+	X0 = ((LONG)pane->W - tgtW)/2;
+	if      ((shiftflag & 0x0003) == PANEL_ATTACH_BOTTOM) Y0 = (LONG)pane->H - tgtH;
+	else if ((shiftflag & 0x0003) == PANEL_ATTACH_TOP)    Y0 = 0;
+	else                                                  Y0 = ((LONG)pane->H - tgtH)/2;
+
+	tgtRect.left   = (X0 >= 0 ? X0 : 0);
+	tgtRect.top    = (Y0 >= 0 ? Y0 : 0);
+	tgtRect.right  = min (tgtRect.left+tgtW, (LONG)pane->W);
+	tgtRect.bottom = min (tgtRect.top+tgtH, (LONG)pane->H);
+
+	srcRect.left   = tgtRect.left-X0;
+	srcRect.top    = tgtRect.top-Y0;
+	srcRect.right  = srcRect.left + (tgtRect.right-tgtRect.left);
+	srcRect.bottom = srcRect.top  + (tgtRect.bottom-tgtRect.top);
+
+	if (scaled) {
+		srcRect.left   = max((LONG)(srcRect.left  *iscale), (LONG)0);
+		srcRect.top    = max((LONG)(srcRect.top   *iscale), (LONG)0);
+		srcRect.right  = min((LONG)(srcRect.right * iscale), srcW);
+		srcRect.bottom = min((LONG)(srcRect.bottom* iscale), srcH);
+	}
+
+	// SURFHANDLE path never carries a Win32 GDI colour-key; callers that
+	// want keyed blits should author the transparent pixels directly.
+	bltflag = 0;
+	has_ck = false;
+
+	visible = true;
+}
+
 void Panel::DefineArea (int aid, const RECT &pos, int draw_mode, int mouse_mode, int bkmode)
 {
 	// sanity-checks

--- a/Src/Orbiter/Panel.h
+++ b/Src/Orbiter/Panel.h
@@ -57,6 +57,12 @@ public:
 	// converts rectangle from unscaled panel space to viewport space
 
 	void DefineBackground (HBITMAP hBmp, DWORD flag, DWORD ck = (DWORD)-1);
+// Alternative entry point for vessels that can't produce an HBITMAP
+// (non-Windows builds whose CreateCompatibleBitmap is a stub). Takes
+// ownership of `hSurf` — it will be released when the panel is torn
+// down. Name-disambiguated from the HBITMAP overload because
+// HBITMAP and SURFHANDLE are both `void*` typedefs on macOS/Linux.
+void DefineBackgroundSurface (SURFHANDLE hSurf, DWORD flag);
 
 	void DefineArea (int aid, const RECT &pos, int draw_mode, int mouse_mode, int bkmode);
 	void ReleaseAreas ();

--- a/Src/Vessel/Dragonfly/Dragonfly.cpp
+++ b/Src/Vessel/Dragonfly/Dragonfly.cpp
@@ -840,7 +840,15 @@ void Dragonfly::RedrawPanel_CGIndicator (SURFHANDLE surf)
 void Dragonfly::LoadPanel(int id)
 { 
 	Internals.PanelList[id].MakeYourBackground();
+#ifdef _WIN32
 	oapiRegisterPanelBackground(Internals.PanelList[id].hBitmap,Internals.PanelList[id].ATT_mode,0xFFFFFF);
+#else
+	// macOS / Linux: MakeYourBackground built the panel through a
+	// Sketchpad-backed SURFHANDLE because the GDI helpers are stubs.
+	// Register it via the SURFHANDLE overload; ownership transfers to
+	// the engine.
+	oapiRegisterPanelBackgroundSurface(Internals.PanelList[id].surf, Internals.PanelList[id].ATT_mode);
+#endif
 	oapiSetPanelNeighbours(Internals.PanelList[id].neighbours[0],Internals.PanelList[id].neighbours[1],Internals.PanelList[id].neighbours[2],Internals.PanelList[id].neighbours[3]);
 	Internals.PanelList[id].RegisterYourInstruments();
     CurrentPANEL=id;

--- a/Src/Vessel/Dragonfly/panel.cpp
+++ b/Src/Vessel/Dragonfly/panel.cpp
@@ -125,7 +125,8 @@ Panel::~Panel()
   };
 };
 void Panel::MakeYourBackground()
-{ 
+{
+#ifdef _WIN32
 	surf=oapiCreateSurface(Wdth,Hght);
 	hDC=oapiGetDC(surf);
 	hDC2=CreateCompatibleDC(hDC);
@@ -142,8 +143,84 @@ void Panel::MakeYourBackground()
 	DeleteDC(hDC2);
 	oapiReleaseDC(surf,hDC);
 	oapiDestroySurface(surf);
+#else
+	// macOS / Linux: every GDI helper the Win32 path uses
+	// (CreateCompatibleBitmap, SelectObject, Rectangle, TextOut, Arc, …)
+	// is an empty stub in OrbiterPlatform.h, so the original code
+	// produced a NULL HBITMAP and an empty panel background (#133). Build
+	// the background through oapi::Sketchpad instead, keep the backing
+	// SURFHANDLE, and hand it to oapiRegisterPanelBackground's SURFHANDLE
+	// overload from Dragonfly::LoadPanel.
+	hBitmap = nullptr;
+	surf = oapiCreateSurface(Wdth, Hght);
+	if (!surf) return;
 
-	
+	oapi::Sketchpad *skp = oapiGetSketchpad(surf);
+	if (!skp) { oapiDestroySurface(surf); surf = nullptr; return; }
+
+	// Panel fill (hBRUSH_Background = RGB(145,48,48)).
+	skp->QuickBrush(RGB(145, 48, 48));
+	skp->QuickPen(0, 0, 0);
+	skp->Rectangle(0, 0, Wdth, Hght);
+
+	// Screws — white outline circle with a diagonal scratch through it.
+	const int di = (int)(5 * sqrt(2.0) / 2);
+	skp->QuickPen(RGB(250, 250, 250), 1, 1);
+	skp->QuickBrush(RGB(145, 48, 48));
+	for (int i = 0; i < screw_num; i++) {
+		int x = Screw_list[i].x, y = Screw_list[i].y;
+		skp->Ellipse(x - 5, y - 5, x + 5, y + 5);
+		skp->Line(x - di, y - di, x + di, y + di);
+	}
+
+	// Labels — red, centre-aligned, transparent background (the GDI path
+	// used SetTextColor RGB(255,100,100) even though the brush handle
+	// naming suggests cyan; we honour the actual rendered colour).
+	skp->SetTextAlign(oapi::Sketchpad::CENTER, oapi::Sketchpad::TOP);
+	skp->SetTextColor(RGB(255, 100, 100));
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+	for (int i = 0; i < text_num; i++) {
+		skp->Text(Text_list[i].x, Text_list[i].y,
+		          Text_list[i].text, (int)strlen(Text_list[i].text));
+	}
+
+	// Column text — short tab frame above/below the label, opaque bg so
+	// the tab cuts through the frame line neatly.
+	skp->QuickPen(RGB(255, 100, 100), 1, 1);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_OPAQUE);
+	skp->SetBackgroundColor(RGB(145, 48, 48));
+	for (int i = 0; i < ctext_num; i++) {
+		const int cx = CText_list[i].x, cy = CText_list[i].y;
+		const int lng = CText_list[i].lngth, dir = CText_list[i].dir;
+		skp->MoveTo(cx + lng / 2, cy + dir * 7 + 5);
+		skp->LineTo(cx + lng / 2, cy + 5);
+		skp->LineTo(cx - lng / 2, cy + 5);
+		skp->LineTo(cx - lng / 2, cy + dir * 7 + 5);
+		skp->Text(cx, cy, CText_list[i].text,
+		          (int)strlen(CText_list[i].text));
+	}
+
+	// Borders — the GDI path rounds each corner with a 5-pixel Arc();
+	// Sketchpad has no arc primitive, so draw square corners. Visually
+	// almost indistinguishable at panel scale.
+	skp->QuickPen(RGB(15, 15, 15), 1, 1);
+	skp->SetBackgroundMode(oapi::Sketchpad::BK_TRANSPARENT);
+	for (int i = 0; i < border_num; i++) {
+		const int px = Border_list[i].x, py = Border_list[i].y;
+		const int nr = Border_list[i].num;
+		const int x0 = px - 5, x1 = px + 45 * nr + 5;
+		const int y0 = py, y1 = py + 40;
+		skp->MoveTo(x0, y0);
+		skp->LineTo(x0, y1);
+		skp->LineTo(x1, y1);
+		skp->LineTo(x1, y0);
+		skp->LineTo(x0, y0);
+	}
+
+	oapiReleaseSketchpad(skp);
+	// Leave `surf` alive; Dragonfly::LoadPanel will hand it to
+	// oapiRegisterPanelBackground(SURFHANDLE,…), which takes ownership.
+#endif
 }
 void Panel::NowPutScrews()
 {int di=5*sqrt(2.0)/2;


### PR DESCRIPTION
## Summary

Partial fix for #133. The Dragonfly 2D panel crashed on load before [kanik0#132](https://github.com/kanik0/orbiter/pull/132) and rendered entirely empty afterwards. This PR reinstates the panel **frame, labels and borders** by re-implementing the background-building path on top of `oapi::Sketchpad`, and adds the public SURFHANDLE-based panel-background API needed to plumb it through. Uncovers and fixes a latent BGR/RGB swap in `OGLSketchpad::PackColor` along the way.

## What changed

**New API** — vessel plugins on macOS/Linux can't produce an `HBITMAP` because `CreateCompatibleBitmap` is a no-op stub in `OrbiterPlatform.h`.
- [`Orbitersdk/include/OrbiterAPI.h`](Orbitersdk/include/OrbiterAPI.h) + [`Src/Orbiter/OrbiterAPI.cpp`](Src/Orbiter/OrbiterAPI.cpp): `oapiRegisterPanelBackgroundSurface(SURFHANDLE, DWORD flag)` — distinct name from the HBITMAP overload because both parameter types collapse to `void*` on macOS/Linux.
- [`Src/Orbiter/Pane.cpp`](Src/Orbiter/Pane.cpp): wires the existing-but-stubbed `Pane::RegisterPanelBackground(SURFHANDLE, DWORD)` to the new panel method.
- [`Src/Orbiter/Panel.h`](Src/Orbiter/Panel.h) + [`.cpp`](Src/Orbiter/Panel.cpp): `Panel::DefineBackgroundSurface(SURFHANDLE, DWORD)` — same scale / attach / tgtRect / srcRect setup as the HBITMAP variant, pulls size via `clbkGetSurfaceSize`, takes ownership and releases at teardown.

**Dragonfly** — [`Src/Vessel/Dragonfly/panel.cpp`](Src/Vessel/Dragonfly/panel.cpp) `Panel::MakeYourBackground` gets a `#ifndef _WIN32` branch that:
- allocates `oapiCreateSurface(Wdth, Hght)`
- grabs a Sketchpad against it
- replays the Win32 flow with `Sketchpad::Rectangle / Ellipse / Line / Text / MoveTo / LineTo`
- flattens the 5-pixel rounded border `Arc()` calls to square corners (Sketchpad has no arc primitive; visually indistinguishable at panel scale)

[`Src/Vessel/Dragonfly/Dragonfly.cpp::LoadPanel`](Src/Vessel/Dragonfly/Dragonfly.cpp) registers via the HBITMAP overload on Windows and the SURFHANDLE overload on macOS/Linux.

**OGLSketchpad BGR/RGB swap** — [`OVP/OGLClient/OGLSketchpad.cpp`](OVP/OGLClient/OGLSketchpad.cpp) `PackColor` documented \"0xBBGGRR\" (R in low byte, matching Windows `RGB()` / D3D9) but actually extracted `(col >> 16) & 0xFF` into the \"r\" variable — the BB byte. Anything non-symmetric (`col_red1 = RGB(255,0,0)`, `col_yellow1 = RGB(230,230,0)`, or the new `RGB(145,48,48)`) rendered with R and B transposed. Stayed hidden because every shipping MFD / HUD uses green / grey / white. Fixed by taking R from the low byte, B from the high byte.

## Known residuals (documented in commit and followup-worthy)

- **Dragonfly instruments** (~230 per-frame GDI calls in `Src/Vessel/Dragonfly/instruments.cpp`) still show as blank black rectangles. Needs either a GDI-compat layer over Sketchpad or a vessel-local rewrite — out of scope for #133 (which was about getting the panel background visible).
- **Panel scroll across neighbours** — on Dragonfly's multi-panel layout (`neighbours[0..3]`), scrolling shows anomalous behaviour on macOS: MFD shifts while background appears to stay, panel eventually vanishes instead of transitioning into a neighbour. Likely coupled to the GDI-compat gap (neighbour panels also rely on the background pipeline). Investigate alongside the instrument rewrite.
- **Native panel size** looks small on 2560×1600 retina displays. User-tunable via `PanelScale = 2.5` in `Orbiter.cfg`; Windows users hit the same trade-off at high DPI.

## Test plan

- [x] Dragonfly scenario loads without crashing (inherited from [kanik0#132](https://github.com/kanik0/orbiter/pull/132)).
- [x] Pressing F3 switches to 2D panel; panel frame, screw markers, section labels and group borders render in dark-red with red text.
- [x] Colour-swap fix verified against DG MODE SELECT (green text unchanged) and Atlantis AscentMFD (green text unchanged).
- [ ] Regression check: every vessel / scenario on the #129 audit matrix still renders the same as on main.

## Related

- Closes #133 partially — the \"panel background visible\" ask is delivered; instrument rendering and scroll are follow-ups.
- Depends on [kanik0#132](https://github.com/kanik0/orbiter/pull/132) (landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)